### PR TITLE
Replace buttons with proper Lock, Switch entities for Alexa/Matter compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ On first setup, Honda will send a verification email. Copy the link URL (don't c
 - Warning lamps, Last updated
 - Trips this month, Distance this month, Driving time this month, Avg consumption this month
 
+### Lock
+- Doors — lock/unlock with state from vehicle
+
+### Switches
+- Climate — start/stop pre-conditioning with state from vehicle
+- Charging — start/stop charging with state from vehicle
+
 ### Buttons
-- Lock doors, Unlock doors, Horn & lights
-- Climate start/stop, Start/stop charging, Refresh from car
+- Horn & lights, Refresh from car
 
 ### Numbers
 - Charge limit (home), Charge limit (away)

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 from .data import MyHondaPlusConfigEntry, MyHondaPlusData
 
-PLATFORMS = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER]
+PLATFORMS = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 from .data import MyHondaPlusConfigEntry, MyHondaPlusData
 
-PLATFORMS = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SWITCH, Platform.LOCK]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -59,4 +59,4 @@ class HondaButton(MyHondaPlusEntity, ButtonEntity):
             await self.coordinator.async_send_command(api.remote_horn_lights, vin)
         elif action == "refresh":
             await self.coordinator.async_refresh_from_car()
-            self.hass.async_create_task(self._delayed_refresh())
+            self._schedule_refresh()

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -36,18 +36,6 @@ BUTTON_DESCRIPTIONS: list[HondaButtonDescription] = [
         action="horn_lights",
     ),
     HondaButtonDescription(
-        key="climate_start",
-        translation_key="climate_start",
-        icon="mdi:air-conditioner",
-        action="climate_start",
-    ),
-    HondaButtonDescription(
-        key="climate_stop",
-        translation_key="climate_stop",
-        icon="mdi:fan-off",
-        action="climate_stop",
-    ),
-    HondaButtonDescription(
         key="charge_start",
         translation_key="charge_start",
         icon="mdi:battery-charging",
@@ -97,10 +85,6 @@ class HondaButton(MyHondaPlusEntity, ButtonEntity):
             await self.coordinator.async_send_command(api.remote_unlock, vin)
         elif action == "horn_lights":
             await self.coordinator.async_send_command(api.remote_horn_lights, vin)
-        elif action == "climate_start":
-            await self.coordinator.async_send_command(api.remote_climate_start, vin)
-        elif action == "climate_stop":
-            await self.coordinator.async_send_command(api.remote_climate_stop, vin)
         elif action == "charge_start":
             await self.coordinator.async_send_command(api.remote_charge_start, vin)
         elif action == "charge_stop":

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -18,34 +18,10 @@ class HondaButtonDescription(ButtonEntityDescription):
 
 BUTTON_DESCRIPTIONS: list[HondaButtonDescription] = [
     HondaButtonDescription(
-        key="lock",
-        translation_key="lock",
-        icon="mdi:car-door-lock",
-        action="lock",
-    ),
-    HondaButtonDescription(
-        key="unlock",
-        translation_key="unlock",
-        icon="mdi:car-door",
-        action="unlock",
-    ),
-    HondaButtonDescription(
         key="horn_lights",
         translation_key="horn_lights",
         icon="mdi:bullhorn",
         action="horn_lights",
-    ),
-    HondaButtonDescription(
-        key="charge_start",
-        translation_key="charge_start",
-        icon="mdi:battery-charging",
-        action="charge_start",
-    ),
-    HondaButtonDescription(
-        key="charge_stop",
-        translation_key="charge_stop",
-        icon="mdi:battery-off",
-        action="charge_stop",
     ),
     HondaButtonDescription(
         key="refresh_data",
@@ -79,16 +55,8 @@ class HondaButton(MyHondaPlusEntity, ButtonEntity):
         api = self.coordinator.api
         vin = self._vin
 
-        if action == "lock":
-            await self.coordinator.async_send_command(api.remote_lock, vin)
-        elif action == "unlock":
-            await self.coordinator.async_send_command(api.remote_unlock, vin)
-        elif action == "horn_lights":
+        if action == "horn_lights":
             await self.coordinator.async_send_command(api.remote_horn_lights, vin)
-        elif action == "charge_start":
-            await self.coordinator.async_send_command(api.remote_charge_start, vin)
-        elif action == "charge_stop":
-            await self.coordinator.async_send_command(api.remote_charge_stop, vin)
         elif action == "refresh":
             await self.coordinator.async_refresh_from_car()
             self.hass.async_create_task(

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -59,11 +59,4 @@ class HondaButton(MyHondaPlusEntity, ButtonEntity):
             await self.coordinator.async_send_command(api.remote_horn_lights, vin)
         elif action == "refresh":
             await self.coordinator.async_refresh_from_car()
-            self.hass.async_create_task(
-                self._delayed_refresh()
-            )
-
-    async def _delayed_refresh(self) -> None:
-        import asyncio
-        await asyncio.sleep(30)
-        await self.coordinator.async_request_refresh()
+            self.hass.async_create_task(self._delayed_refresh())

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -60,6 +60,13 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
             self.hass, delay, self._do_refresh,
         )
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel pending refresh on removal."""
+        if self._refresh_unsub:
+            self._refresh_unsub()
+            self._refresh_unsub = None
+        await super().async_will_remove_from_hass()
+
     @callback
     def _do_refresh(self, _now) -> None:
         """Trigger coordinator refresh."""

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -1,8 +1,8 @@
 """Base entity for My Honda+."""
 
-import asyncio
-
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -22,6 +22,7 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
     """Base class for My Honda+ entities."""
 
     _attr_has_entity_name = True
+    _refresh_unsub: CALLBACK_TYPE | None = None
 
     def __init__(
         self,
@@ -51,7 +52,16 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
             info["model"] = model
         return info
 
-    async def _delayed_refresh(self, delay: int = 30) -> None:
-        """Wait, then refresh coordinator data from the car."""
-        await asyncio.sleep(delay)
-        await self.coordinator.async_request_refresh()
+    def _schedule_refresh(self, delay: int = 30) -> None:
+        """Schedule a coordinator refresh, replacing any pending one."""
+        if self._refresh_unsub:
+            self._refresh_unsub()
+        self._refresh_unsub = async_call_later(
+            self.hass, delay, self._do_refresh,
+        )
+
+    @callback
+    def _do_refresh(self, _now) -> None:
+        """Trigger coordinator refresh."""
+        self._refresh_unsub = None
+        self.hass.async_create_task(self.coordinator.async_request_refresh())

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -1,5 +1,7 @@
 """Base entity for My Honda+."""
 
+import asyncio
+
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -48,3 +50,8 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
         if model:
             info["model"] = model
         return info
+
+    async def _delayed_refresh(self, delay: int = 30) -> None:
+        """Wait, then refresh coordinator data from the car."""
+        await asyncio.sleep(delay)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -49,10 +49,12 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         """Lock the doors."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_lock, self._vin)
+        self.coordinator.data["doors_locked"] = True
         self.async_write_ha_state()
 
     async def async_unlock(self, **kwargs) -> None:
         """Unlock the doors."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_unlock, self._vin)
+        self.coordinator.data["doors_locked"] = False
         self.async_write_ha_state()

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -49,14 +49,16 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         """Lock the doors."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_lock, self._vin)
-        self.coordinator.data["doors_locked"] = True
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["doors_locked"] = True
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()
 
     async def async_unlock(self, **kwargs) -> None:
         """Unlock the doors."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_unlock, self._vin)
-        self.coordinator.data["doors_locked"] = False
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["doors_locked"] = False
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -1,0 +1,58 @@
+"""Lock platform for My Honda+."""
+
+from homeassistant.components.lock import LockEntity, LockEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_VEHICLE_NAME, CONF_VIN
+from .data import MyHondaPlusConfigEntry
+from .entity import MyHondaPlusEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up My Honda+ locks."""
+    coordinator = entry.runtime_data.coordinator
+    vin = entry.data[CONF_VIN]
+    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
+    async_add_entities([HondaDoorLock(coordinator, vin, vehicle_name)])
+
+
+class HondaDoorLock(MyHondaPlusEntity, LockEntity):
+    """Lock entity for Honda door locks."""
+
+    _attr_translation_key = "doors"
+
+    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+        description = LockEntityDescription(
+            key="doors",
+            translation_key="doors",
+        )
+        super().__init__(coordinator, description, vin, vehicle_name)
+
+    @property
+    def is_locked(self) -> bool | None:
+        """Return true if doors are locked."""
+        value = self.coordinator.data.get("doors_locked")
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "on", "yes", "1", "locked")
+        return bool(value)
+
+    async def async_lock(self, **kwargs) -> None:
+        """Lock the doors."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_lock, self._vin)
+        self.async_write_ha_state()
+
+    async def async_unlock(self, **kwargs) -> None:
+        """Unlock the doors."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_unlock, self._vin)
+        self.async_write_ha_state()

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -51,6 +51,7 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         await self.coordinator.async_send_command(api.remote_lock, self._vin)
         self.coordinator.data["doors_locked"] = True
         self.async_write_ha_state()
+        self.hass.async_create_task(self._delayed_refresh())
 
     async def async_unlock(self, **kwargs) -> None:
         """Unlock the doors."""
@@ -58,3 +59,4 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         await self.coordinator.async_send_command(api.remote_unlock, self._vin)
         self.coordinator.data["doors_locked"] = False
         self.async_write_ha_state()
+        self.hass.async_create_task(self._delayed_refresh())

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -77,11 +77,12 @@
       "lock": { "name": "Lock doors" },
       "unlock": { "name": "Unlock doors" },
       "horn_lights": { "name": "Horn & lights" },
-      "climate_start": { "name": "Climate start" },
-      "climate_stop": { "name": "Climate stop" },
       "charge_start": { "name": "Start charging" },
       "charge_stop": { "name": "Stop charging" },
       "refresh_data": { "name": "Refresh from car" }
+    },
+    "switch": {
+      "climate": { "name": "Climate" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -74,15 +74,15 @@
       "avg_consumption_this_month": { "name": "Avg consumption this month" }
     },
     "button": {
-      "lock": { "name": "Lock doors" },
-      "unlock": { "name": "Unlock doors" },
       "horn_lights": { "name": "Horn & lights" },
-      "charge_start": { "name": "Start charging" },
-      "charge_stop": { "name": "Stop charging" },
       "refresh_data": { "name": "Refresh from car" }
     },
+    "lock": {
+      "doors": { "name": "Doors" }
+    },
     "switch": {
-      "climate": { "name": "Climate" }
+      "climate": { "name": "Climate" },
+      "charging": { "name": "Charging" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -58,17 +58,19 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         """Start climate pre-conditioning."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_climate_start, self._vin)
-        self.coordinator.data["climate_active"] = True
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["climate_active"] = True
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_climate_stop, self._vin)
-        self.coordinator.data["climate_active"] = False
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["climate_active"] = False
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()
 
 
 class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -101,14 +103,16 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         """Start charging."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_charge_start, self._vin)
-        self.coordinator.data["charge_status"] = "charging"
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["charge_status"] = "charging"
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_charge_stop, self._vin)
-        self.coordinator.data["charge_status"] = "not_charging"
-        self.async_write_ha_state()
-        self.hass.async_create_task(self._delayed_refresh())
+        data = dict(self.coordinator.data)
+        data["charge_status"] = "not_charging"
+        self.coordinator.async_set_updated_data(data)
+        self._schedule_refresh()

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -1,6 +1,6 @@
 """Switch platform for My Honda+."""
 
-from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass, SwitchEntityDescription
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -1,6 +1,10 @@
 """Switch platform for My Honda+."""
 
-from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -1,0 +1,63 @@
+"""Switch platform for My Honda+."""
+
+from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_VEHICLE_NAME, CONF_VIN
+from .data import MyHondaPlusConfigEntry
+from .entity import MyHondaPlusEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up My Honda+ switches."""
+    coordinator = entry.runtime_data.coordinator
+    vin = entry.data[CONF_VIN]
+    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
+    async_add_entities([HondaClimateSwitch(coordinator, vin, vehicle_name)])
+
+
+class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
+    """Switch to start/stop climate pre-conditioning."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:air-conditioner"
+    _attr_translation_key = "climate"
+
+    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+        """Initialize the climate switch."""
+        from homeassistant.components.switch import SwitchEntityDescription
+
+        description = SwitchEntityDescription(
+            key="climate",
+            translation_key="climate",
+        )
+        super().__init__(coordinator, description, vin, vehicle_name)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if climate is active."""
+        value = self.coordinator.data.get("climate_active")
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "on", "yes", "1", "active")
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Start climate pre-conditioning."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_climate_start, self._vin)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop climate pre-conditioning."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_climate_stop, self._vin)
+        self.async_write_ha_state()

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -58,13 +58,17 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         """Start climate pre-conditioning."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_climate_start, self._vin)
+        self.coordinator.data["climate_active"] = True
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_climate_stop, self._vin)
+        self.coordinator.data["climate_active"] = False
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
 
 class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -97,10 +101,14 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         """Start charging."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_charge_start, self._vin)
+        self.coordinator.data["charge_status"] = "charging"
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_charge_stop, self._vin)
+        self.coordinator.data["charge_status"] = "not_charging"
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -94,7 +94,7 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
-            return value.lower() in ("charging",)
+            return value.lower() in ("charging", "running")
         return bool(value)
 
     async def async_turn_on(self, **kwargs) -> None:

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -1,6 +1,6 @@
 """Switch platform for My Honda+."""
 
-from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -18,7 +18,10 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     vin = entry.data[CONF_VIN]
     vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities([HondaClimateSwitch(coordinator, vin, vehicle_name)])
+    async_add_entities([
+        HondaClimateSwitch(coordinator, vin, vehicle_name),
+        HondaChargeSwitch(coordinator, vin, vehicle_name),
+    ])
 
 
 class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -29,9 +32,6 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
     _attr_translation_key = "climate"
 
     def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
-        """Initialize the climate switch."""
-        from homeassistant.components.switch import SwitchEntityDescription
-
         description = SwitchEntityDescription(
             key="climate",
             translation_key="climate",
@@ -60,4 +60,43 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         """Stop climate pre-conditioning."""
         api = self.coordinator.api
         await self.coordinator.async_send_command(api.remote_climate_stop, self._vin)
+        self.async_write_ha_state()
+
+
+class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
+    """Switch to start/stop charging."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:ev-station"
+    _attr_translation_key = "charging"
+
+    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+        description = SwitchEntityDescription(
+            key="charging",
+            translation_key="charging",
+        )
+        super().__init__(coordinator, description, vin, vehicle_name)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if charging is active."""
+        value = self.coordinator.data.get("charge_status")
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("charging",)
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Start charging."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_charge_start, self._vin)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop charging."""
+        api = self.coordinator.api
+        await self.coordinator.async_send_command(api.remote_charge_stop, self._vin)
         self.async_write_ha_state()

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -60,7 +60,7 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         await self.coordinator.async_send_command(api.remote_climate_start, self._vin)
         self.coordinator.data["climate_active"] = True
         self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._delayed_refresh())
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
@@ -68,7 +68,7 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         await self.coordinator.async_send_command(api.remote_climate_stop, self._vin)
         self.coordinator.data["climate_active"] = False
         self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._delayed_refresh())
 
 
 class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -103,7 +103,7 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         await self.coordinator.async_send_command(api.remote_charge_start, self._vin)
         self.coordinator.data["charge_status"] = "charging"
         self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._delayed_refresh())
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
@@ -111,4 +111,4 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         await self.coordinator.async_send_command(api.remote_charge_stop, self._vin)
         self.coordinator.data["charge_status"] = "not_charging"
         self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self._delayed_refresh())

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -77,11 +77,12 @@
       "lock": { "name": "Lock doors" },
       "unlock": { "name": "Unlock doors" },
       "horn_lights": { "name": "Horn & lights" },
-      "climate_start": { "name": "Climate start" },
-      "climate_stop": { "name": "Climate stop" },
       "charge_start": { "name": "Start charging" },
       "charge_stop": { "name": "Stop charging" },
       "refresh_data": { "name": "Refresh from car" }
+    },
+    "switch": {
+      "climate": { "name": "Climate" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -74,15 +74,15 @@
       "avg_consumption_this_month": { "name": "Avg consumption this month" }
     },
     "button": {
-      "lock": { "name": "Lock doors" },
-      "unlock": { "name": "Unlock doors" },
       "horn_lights": { "name": "Horn & lights" },
-      "charge_start": { "name": "Start charging" },
-      "charge_stop": { "name": "Stop charging" },
       "refresh_data": { "name": "Refresh from car" }
     },
+    "lock": {
+      "doors": { "name": "Doors" }
+    },
     "switch": {
-      "climate": { "name": "Climate" }
+      "climate": { "name": "Climate" },
+      "charging": { "name": "Charging" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },


### PR DESCRIPTION
## Summary

- **Climate control**: start/stop buttons → **Switch** entity (state from `climate_active`)
- **Door locks**: lock/unlock buttons → **Lock** entity (state from `doors_locked`)
- **Charging**: start/stop buttons → **Switch** entity (state from `charge_status`)
- **Remaining buttons**: horn & lights, refresh from car (stateless actions, correct as buttons)
- All stateful entities use **optimistic state updates** after successful API calls, so the UI and voice assistants reflect changes immediately

These proper HA platforms are natively supported by Alexa, Matter, Google Home, and other voice assistants.

## Test plan

- [ ] Verify climate switch toggles on/off and reflects `climate_active` state
- [ ] Verify door lock entity locks/unlocks and reflects `doors_locked` state
- [ ] Verify charging switch toggles on/off and reflects `charge_status` state
- [ ] Verify horn & lights and refresh buttons still work
- [ ] Test with Alexa / Matter bridge to confirm voice control works

https://claude.ai/code/session_01R9NoWQN7JC2dxCgWpRHRQJ