### PR TITLE
Fix: handle 502 errors gracefully during car refresh

### DIFF
--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pymyhondaplus.api import (
     HondaAPI,
@@ -73,6 +73,9 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self._persist_tokens_if_changed()
             if err.status_code == 401:
                 raise ConfigEntryAuthFailed from err
+            if err.status_code and err.status_code >= 500 and self.data is not None:
+                LOGGER.warning("Transient server error (%s), keeping cached data", err)
+                return self.data
             raise UpdateFailed(str(err)) from err
         except Exception as err:
             raise UpdateFailed(str(err)) from err
@@ -81,13 +84,25 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         return data
 
     async def async_refresh_from_car(self) -> None:
-        await self.hass.async_add_executor_job(
-            self.api.request_dashboard_refresh, self.vin,
-        )
+        try:
+            await self.hass.async_add_executor_job(
+                self.api.request_dashboard_refresh, self.vin,
+            )
+        except HondaAPIError as err:
+            self._persist_tokens_if_changed()
+            if err.status_code == 401:
+                raise ConfigEntryAuthFailed from err
+            raise HomeAssistantError(f"Refresh failed: {err}") from err
         self._persist_tokens_if_changed()
 
     async def async_send_command(self, func, *args) -> str:
-        result = await self.hass.async_add_executor_job(func, *args)
+        try:
+            result = await self.hass.async_add_executor_job(func, *args)
+        except HondaAPIError as err:
+            self._persist_tokens_if_changed()
+            if err.status_code == 401:
+                raise ConfigEntryAuthFailed from err
+            raise HomeAssistantError(f"Command failed: {err}") from err
         self._persist_tokens_if_changed()
         return result
 
@@ -125,6 +140,9 @@ class HondaTripCoordinator(DataUpdateCoordinator[dict]):
             self._persist_tokens()
             if err.status_code == 401:
                 raise ConfigEntryAuthFailed from err
+            if err.status_code and err.status_code >= 500 and self.data is not None:
+                LOGGER.warning("Transient server error (%s), keeping cached data", err)
+                return self.data
             raise UpdateFailed(str(err)) from err
         except Exception as err:
             raise UpdateFailed(str(err)) from err

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -28,6 +28,25 @@ from .const import (
 )
 
 
+def _handle_api_error(
+    err: HondaAPIError,
+    persist_tokens: callable,
+    cached_data: dict | None = None,
+) -> dict | None:
+    """Handle HondaAPIError consistently across coordinators.
+
+    Returns cached data for transient 5xx errors, raises
+    ConfigEntryAuthFailed for 401, or raises UpdateFailed/HomeAssistantError.
+    """
+    persist_tokens()
+    if err.status_code == 401:
+        raise ConfigEntryAuthFailed from err
+    if err.status_code and err.status_code >= 500 and cached_data is not None:
+        LOGGER.warning("Transient server error (%s), keeping cached data", err.status_code)
+        return cached_data
+    return None
+
+
 class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -70,12 +89,11 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         try:
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
-            self._persist_tokens_if_changed()
-            if err.status_code == 401:
-                raise ConfigEntryAuthFailed from err
-            if err.status_code and err.status_code >= 500 and self.data is not None:
-                LOGGER.warning("Transient server error (%s), keeping cached data", err)
-                return self.data
+            cached = _handle_api_error(
+                err, self._persist_tokens_if_changed, self.data,
+            )
+            if cached is not None:
+                return cached
             raise UpdateFailed(str(err)) from err
         except Exception as err:
             raise UpdateFailed(str(err)) from err
@@ -89,20 +107,22 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                 self.api.request_dashboard_refresh, self.vin,
             )
         except HondaAPIError as err:
-            self._persist_tokens_if_changed()
-            if err.status_code == 401:
-                raise ConfigEntryAuthFailed from err
-            raise HomeAssistantError(f"Refresh failed: {err}") from err
+            _handle_api_error(err, self._persist_tokens_if_changed)
+            LOGGER.error("Dashboard refresh failed: %s", err)
+            raise HomeAssistantError(
+                "Unable to refresh data from vehicle"
+            ) from err
         self._persist_tokens_if_changed()
 
     async def async_send_command(self, func, *args) -> str:
         try:
             result = await self.hass.async_add_executor_job(func, *args)
         except HondaAPIError as err:
-            self._persist_tokens_if_changed()
-            if err.status_code == 401:
-                raise ConfigEntryAuthFailed from err
-            raise HomeAssistantError(f"Command failed: {err}") from err
+            _handle_api_error(err, self._persist_tokens_if_changed)
+            LOGGER.error("Remote command failed: %s", err)
+            raise HomeAssistantError(
+                "Unable to send command to vehicle"
+            ) from err
         self._persist_tokens_if_changed()
         return result
 
@@ -137,12 +157,11 @@ class HondaTripCoordinator(DataUpdateCoordinator[dict]):
         try:
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
-            self._persist_tokens()
-            if err.status_code == 401:
-                raise ConfigEntryAuthFailed from err
-            if err.status_code and err.status_code >= 500 and self.data is not None:
-                LOGGER.warning("Transient server error (%s), keeping cached data", err)
-                return self.data
+            cached = _handle_api_error(
+                err, self._persist_tokens, self.data,
+            )
+            if cached is not None:
+                return cached
             raise UpdateFailed(str(err)) from err
         except Exception as err:
             raise UpdateFailed(str(err)) from err

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,189 @@
+"""Tests for the coordinator."""
+
+from collections import namedtuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pymyhondaplus.api import HondaAPIError
+
+from custom_components.myhondaplus.coordinator import (
+    HondaDataUpdateCoordinator,
+    HondaTripCoordinator,
+)
+
+from .conftest import MOCK_DASHBOARD_DATA, MOCK_ENTRY_DATA, MOCK_VIN
+
+Tokens = namedtuple("Tokens", ["access_token", "refresh_token"])
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    hass.config_entries = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_entry():
+    entry = MagicMock()
+    entry.data = dict(MOCK_ENTRY_DATA)
+    return entry
+
+
+@pytest.fixture
+def coordinator(mock_hass, mock_entry):
+    with patch.object(HondaDataUpdateCoordinator, "__init__", lambda self, *a, **kw: None):
+        coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
+        coord.hass = mock_hass
+        coord.entry = mock_entry
+        coord.vin = MOCK_VIN
+        coord.api = MagicMock()
+        coord.api.tokens = Tokens("fake-access-token", "fake-refresh-token")
+        coord.data = dict(MOCK_DASHBOARD_DATA)
+        coord.logger = MagicMock()
+        return coord
+
+
+@pytest.fixture
+def trip_coordinator(mock_hass, mock_entry):
+    with patch.object(HondaTripCoordinator, "__init__", lambda self, *a, **kw: None):
+        coord = HondaTripCoordinator.__new__(HondaTripCoordinator)
+        coord.hass = mock_hass
+        coord.entry = mock_entry
+        coord.vin = MOCK_VIN
+        coord.api = MagicMock()
+        coord.api.tokens = Tokens("fake-access-token", "fake-refresh-token")
+        coord._persist_tokens = MagicMock()
+        coord._fuel_type = "E"
+        coord.data = {"trips": 10, "total_km": 200}
+        coord.logger = MagicMock()
+        return coord
+
+
+class TestHondaDataUpdateCoordinator:
+    @pytest.mark.asyncio
+    async def test_update_success(self, coordinator):
+        coordinator.hass.async_add_executor_job.return_value = dict(MOCK_DASHBOARD_DATA)
+        result = await coordinator._async_update_data()
+        assert result["battery_level"] == 75
+
+    @pytest.mark.asyncio
+    async def test_update_401_raises_auth_failed(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(401, "Unauthorized")
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_502_returns_cached_data(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        result = await coordinator._async_update_data()
+        assert result == coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_update_500_returns_cached_data(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Internal Server Error")
+        result = await coordinator._async_update_data()
+        assert result == coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_update_503_returns_cached_data(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(503, "Service Unavailable")
+        result = await coordinator._async_update_data()
+        assert result == coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_update_500_no_cached_data_raises(self, coordinator):
+        coordinator.data = None
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Internal Server Error")
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_400_raises_update_failed(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(400, "Bad Request")
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_generic_exception_raises(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = RuntimeError("boom")
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_refresh_from_car_success(self, coordinator):
+        coordinator.hass.async_add_executor_job.return_value = None
+        await coordinator.async_refresh_from_car()
+        coordinator.hass.async_add_executor_job.assert_awaited_once_with(
+            coordinator.api.request_dashboard_refresh, MOCK_VIN,
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_from_car_401(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(401, "Unauthorized")
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator.async_refresh_from_car()
+
+    @pytest.mark.asyncio
+    async def test_refresh_from_car_502(self, coordinator):
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        with pytest.raises(HomeAssistantError, match="Refresh failed"):
+            await coordinator.async_refresh_from_car()
+
+    @pytest.mark.asyncio
+    async def test_send_command_success(self, coordinator):
+        func = MagicMock()
+        coordinator.hass.async_add_executor_job.return_value = "ok"
+        result = await coordinator.async_send_command(func, "arg1", "arg2")
+        assert result == "ok"
+        coordinator.hass.async_add_executor_job.assert_awaited_once_with(func, "arg1", "arg2")
+
+    @pytest.mark.asyncio
+    async def test_send_command_401(self, coordinator):
+        func = MagicMock()
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(401, "Unauthorized")
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator.async_send_command(func)
+
+    @pytest.mark.asyncio
+    async def test_send_command_500(self, coordinator):
+        func = MagicMock()
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Error")
+        with pytest.raises(HomeAssistantError, match="Command failed"):
+            await coordinator.async_send_command(func)
+
+
+class TestHondaTripCoordinator:
+    @pytest.mark.asyncio
+    async def test_update_success(self, trip_coordinator):
+        trip_coordinator.hass.async_add_executor_job.return_value = {"trips": 5}
+        result = await trip_coordinator._async_update_data()
+        assert result == {"trips": 5}
+
+    @pytest.mark.asyncio
+    async def test_update_401_raises_auth_failed(self, trip_coordinator):
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(401, "Unauthorized")
+        with pytest.raises(ConfigEntryAuthFailed):
+            await trip_coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_502_returns_cached_data(self, trip_coordinator):
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        result = await trip_coordinator._async_update_data()
+        assert result == trip_coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_update_500_no_cached_data_raises(self, trip_coordinator):
+        trip_coordinator.data = None
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Error")
+        with pytest.raises(UpdateFailed):
+            await trip_coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_400_raises_update_failed(self, trip_coordinator):
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(400, "Bad Request")
+        with pytest.raises(UpdateFailed):
+            await trip_coordinator._async_update_data()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -130,7 +130,7 @@ class TestHondaDataUpdateCoordinator:
     @pytest.mark.asyncio
     async def test_refresh_from_car_502(self, coordinator):
         coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
-        with pytest.raises(HomeAssistantError, match="Refresh failed"):
+        with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
             await coordinator.async_refresh_from_car()
 
     @pytest.mark.asyncio
@@ -152,7 +152,7 @@ class TestHondaDataUpdateCoordinator:
     async def test_send_command_500(self, coordinator):
         func = MagicMock()
         coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Error")
-        with pytest.raises(HomeAssistantError, match="Command failed"):
+        with pytest.raises(HomeAssistantError, match="Unable to send command"):
             await coordinator.async_send_command(func)
 
 


### PR DESCRIPTION
## Summary

- **5xx transient errors now preserve cached data** instead of raising `UpdateFailed`, so entities stay available when Honda's API returns 502/503/etc.
- **`async_refresh_from_car()` now has error handling** — previously a 502 would propagate unhandled and crash the button press. Now it raises `HomeAssistantError` which shows a clean toast in the UI.
- **`async_send_command()` also gets error handling** — lock/climate/charging commands now surface failures as UI notifications instead of unhandled exceptions.

## Test plan

- [ ] Press "Refresh from car" when Honda API is healthy — should work as before
- [ ] Verify that a 502 from the API during scheduled update keeps entities available with last known values (warning logged)
- [ ] Verify that a 502 during "Refresh from car" shows a toast error instead of crashing
- [ ] Verify that 401 errors still trigger re-authentication flow

https://claude.ai/code/session_01UVRcsh5WW9BpMhMe3fEZ4M