### PR TITLE
Add climate sensors and enhanced climate control

### DIFF
--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==3.0.0"],
-  "version": "3.0.0-beta.1"
+  "version": "3.0.0-beta.2"
 }

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -182,6 +182,24 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         translation_key="last_updated",
         icon="mdi:clock-outline",
     ),
+    HondaSensorDescription(
+        key="climate_temp",
+        translation_key="climate_temp",
+        icon="mdi:thermometer",
+    ),
+    HondaSensorDescription(
+        key="climate_duration",
+        translation_key="climate_duration",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:timer-outline",
+    ),
+    HondaSensorDescription(
+        key="climate_defrost",
+        translation_key="climate_defrost",
+        icon="mdi:car-defrost-rear",
+    ),
 ]
 
 

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -71,7 +71,10 @@
       "trips_this_month": { "name": "Trips this month" },
       "distance_this_month": { "name": "Distance this month" },
       "driving_time_this_month": { "name": "Driving time this month" },
-      "avg_consumption_this_month": { "name": "Avg consumption this month" }
+      "avg_consumption_this_month": { "name": "Avg consumption this month" },
+      "climate_temp": { "name": "Climate temperature" },
+      "climate_duration": { "name": "Climate duration" },
+      "climate_defrost": { "name": "Climate defrost" }
     },
     "button": {
       "horn_lights": { "name": "Horn & lights" },

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -55,9 +55,15 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
         return bool(value)
 
     async def async_turn_on(self, **kwargs) -> None:
-        """Start climate pre-conditioning."""
+        """Start climate pre-conditioning using saved settings."""
         api = self.coordinator.api
-        await self.coordinator.async_send_command(api.remote_climate_start, self._vin)
+        data = self.coordinator.data or {}
+        temp = data.get("climate_temp", "normal")
+        duration = data.get("climate_duration", 30)
+        defrost = data.get("climate_defrost", True)
+        await self.coordinator.async_send_command(
+            api.remote_climate_on, self._vin, temp, duration, defrost,
+        )
         data = dict(self.coordinator.data)
         data["climate_active"] = True
         self.coordinator.async_set_updated_data(data)

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -71,7 +71,10 @@
       "trips_this_month": { "name": "Trips this month" },
       "distance_this_month": { "name": "Distance this month" },
       "driving_time_this_month": { "name": "Driving time this month" },
-      "avg_consumption_this_month": { "name": "Avg consumption this month" }
+      "avg_consumption_this_month": { "name": "Avg consumption this month" },
+      "climate_temp": { "name": "Climate temperature" },
+      "climate_duration": { "name": "Climate duration" },
+      "climate_defrost": { "name": "Climate defrost" }
     },
     "button": {
       "horn_lights": { "name": "Horn & lights" },

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -58,7 +58,8 @@ class TestClimateSwitch:
     async def test_turn_on(self, climate_switch):
         await climate_switch.async_turn_on()
         climate_switch.coordinator.async_send_command.assert_awaited_once_with(
-            climate_switch.coordinator.api.remote_climate_start, MOCK_VIN,
+            climate_switch.coordinator.api.remote_climate_on,
+            MOCK_VIN, "normal", 30, True,
         )
         climate_switch.coordinator.async_set_updated_data.assert_called_once()
         data = climate_switch.coordinator.async_set_updated_data.call_args[0][0]


### PR DESCRIPTION
## Summary

- **New sensors**: Climate temperature (cooler/normal/hotter), climate duration (minutes), climate defrost (on/off)
- **Enhanced climate switch**: Uses `remote_climate_on()` with the vehicle's saved temperature, duration, and defrost settings instead of the basic `remote_climate_start()`

## Test plan

- [ ] Verify new climate sensors appear and show correct values
- [ ] Toggle climate switch — should use saved settings (temp, duration, defrost)
- [ ] Confirm existing sensors still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)