### PR TITLE
Add charge and climate schedule sensors and services

### DIFF
--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -1,12 +1,22 @@
 """My Honda+ integration for Home Assistant."""
 
+import voluptuous as vol
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
+from .const import DOMAIN
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 from .data import MyHondaPlusConfigEntry, MyHondaPlusData
 
 PLATFORMS = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SWITCH, Platform.LOCK]
+
+SERVICE_SET_CHARGE_SCHEDULE = "set_charge_schedule"
+SERVICE_SET_CLIMATE_SCHEDULE = "set_climate_schedule"
+
+SCHEDULE_RULE_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+SERVICE_SCHEDULE_SCHEMA = vol.Schema({
+    vol.Required("rules"): [SCHEDULE_RULE_SCHEMA],
+})
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
@@ -26,12 +36,56 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _register_services(hass)
     return True
+
+
+def _get_coordinator(hass: HomeAssistant) -> HondaDataUpdateCoordinator:
+    """Get the first available coordinator."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if hasattr(entry, "runtime_data") and entry.runtime_data:
+            return entry.runtime_data.coordinator
+    raise ValueError("No My Honda+ config entry found")
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register integration services (idempotent)."""
+    if hass.services.has_service(DOMAIN, SERVICE_SET_CHARGE_SCHEDULE):
+        return
+
+    async def handle_set_charge_schedule(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        rules = call.data["rules"]
+        await coordinator.async_send_command(
+            coordinator.api.set_charge_schedule, coordinator.vin, rules,
+        )
+        await coordinator.async_request_refresh()
+
+    async def handle_set_climate_schedule(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        rules = call.data["rules"]
+        await coordinator.async_send_command(
+            coordinator.api.set_climate_schedule, coordinator.vin, rules,
+        )
+        await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_CHARGE_SCHEDULE,
+        handle_set_charge_schedule, schema=SERVICE_SCHEDULE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_CLIMATE_SCHEDULE,
+        handle_set_climate_schedule, schema=SERVICE_SCHEDULE_SCHEMA,
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if result and not hass.config_entries.async_entries(DOMAIN):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_CHARGE_SCHEDULE)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_CLIMATE_SCHEDULE)
+    return result
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> None:

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -2,7 +2,8 @@
 
 import voluptuous as vol
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
@@ -53,13 +54,37 @@ def _register_services(hass: HomeAssistant) -> None:
     if hass.services.has_service(DOMAIN, SERVICE_SET_CHARGE_SCHEDULE):
         return
 
+    def _optimistic_schedule_update(
+        coordinator: HondaDataUpdateCoordinator,
+        key: str,
+        rules: list[dict],
+    ) -> None:
+        """Optimistically update schedule data and schedule a delayed refresh."""
+        enriched = []
+        for r in rules:
+            rule = dict(r)
+            rule.setdefault("enabled", True)
+            days = rule.get("days", "")
+            if isinstance(days, str):
+                rule["days"] = [d.strip() for d in days.split(",") if d.strip()]
+            enriched.append(rule)
+        data = dict(coordinator.data)
+        data[key] = enriched
+        coordinator.async_set_updated_data(data)
+
+        @callback
+        def _refresh(_now):
+            hass.async_create_task(coordinator.async_request_refresh())
+
+        async_call_later(hass, 30, _refresh)
+
     async def handle_set_charge_schedule(call: ServiceCall) -> None:
         coordinator = _get_coordinator(hass)
         rules = call.data["rules"]
         await coordinator.async_send_command(
             coordinator.api.set_charge_schedule, coordinator.vin, rules,
         )
-        await coordinator.async_request_refresh()
+        _optimistic_schedule_update(coordinator, "charge_schedule", rules)
 
     async def handle_set_climate_schedule(call: ServiceCall) -> None:
         coordinator = _get_coordinator(hass)
@@ -67,7 +92,7 @@ def _register_services(hass: HomeAssistant) -> None:
         await coordinator.async_send_command(
             coordinator.api.set_climate_schedule, coordinator.vin, rules,
         )
-        await coordinator.async_request_refresh()
+        _optimistic_schedule_update(coordinator, "climate_schedule", rules)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_CHARGE_SCHEDULE,

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -10,6 +10,8 @@ from pymyhondaplus.api import (
     HondaAPI,
     HondaAPIError,
     compute_trip_stats,
+    parse_charge_schedule,
+    parse_climate_schedule,
     parse_ev_status,
 )
 
@@ -83,7 +85,10 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
 
     def _fetch_data(self) -> dict:
         dashboard = self.api.get_dashboard_cached(self.vin)
-        return parse_ev_status(dashboard)
+        data = parse_ev_status(dashboard)
+        data["charge_schedule"] = parse_charge_schedule(dashboard)
+        data["climate_schedule"] = parse_climate_schedule(dashboard)
+        return data
 
     async def _async_update_data(self) -> dict:
         try:

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==3.0.0"],
-  "version": "3.0.0-beta.2"
+  "version": "3.0.0-beta.3"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==3.0.0"],
-  "version": "3.0.0-beta.3"
+  "version": "3.0.0-beta.4"
 }

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -200,6 +200,16 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         translation_key="climate_defrost",
         icon="mdi:car-defrost-rear",
     ),
+    HondaSensorDescription(
+        key="charge_schedule",
+        translation_key="charge_schedule",
+        icon="mdi:calendar-clock",
+    ),
+    HondaSensorDescription(
+        key="climate_schedule",
+        translation_key="climate_schedule",
+        icon="mdi:calendar-clock",
+    ),
 ]
 
 
@@ -265,12 +275,19 @@ def _resolve_unit(data: dict, description: HondaSensorDescription) -> str | None
     return units.get(description.dynamic_unit)
 
 
+SCHEDULE_KEYS = {"charge_schedule", "climate_schedule"}
+
+
 class HondaSensor(MyHondaPlusEntity, SensorEntity):
     """My Honda+ sensor entity."""
 
     @property
     def native_value(self):
         value = self.coordinator.data.get(self.entity_description.key)
+        if self.entity_description.key in SCHEDULE_KEYS:
+            if not isinstance(value, list):
+                return 0
+            return sum(1 for r in value if r.get("enabled"))
         if isinstance(value, list):
             return ", ".join(str(v) for v in value) if value else "none"
         return value
@@ -278,6 +295,15 @@ class HondaSensor(MyHondaPlusEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         return _resolve_unit(self.coordinator.data, self.entity_description)
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        if self.entity_description.key not in SCHEDULE_KEYS:
+            return None
+        value = self.coordinator.data.get(self.entity_description.key)
+        if not isinstance(value, list):
+            return None
+        return {"rules": value}
 
 
 class HondaTripSensor(MyHondaPlusEntity, SensorEntity):

--- a/custom_components/myhondaplus/services.yaml
+++ b/custom_components/myhondaplus/services.yaml
@@ -1,0 +1,27 @@
+set_charge_schedule:
+  name: Set charge prohibition schedule
+  description: Set the charge prohibition schedule (up to 2 rules). Pass an empty list to clear.
+  fields:
+    rules:
+      name: Rules
+      description: >
+        List of up to 2 schedule rules. Each rule has: days (comma-separated, e.g. "mon,tue,wed"),
+        location ("home" or "all"), start_time ("HH:MM"), end_time ("HH:MM").
+      required: true
+      example: '[{"days": "mon,tue,wed,thu,fri", "location": "home", "start_time": "22:00", "end_time": "06:00"}]'
+      selector:
+        object:
+
+set_climate_schedule:
+  name: Set climate schedule
+  description: Set the climate pre-conditioning schedule (up to 7 rules). Pass an empty list to clear.
+  fields:
+    rules:
+      name: Rules
+      description: >
+        List of up to 7 schedule rules. Each rule has: days (comma-separated, e.g. "mon,tue,wed"),
+        start_time ("HH:MM").
+      required: true
+      example: '[{"days": "mon,tue,wed,thu,fri", "start_time": "07:00"}]'
+      selector:
+        object:

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -74,7 +74,9 @@
       "avg_consumption_this_month": { "name": "Avg consumption this month" },
       "climate_temp": { "name": "Climate temperature" },
       "climate_duration": { "name": "Climate duration" },
-      "climate_defrost": { "name": "Climate defrost" }
+      "climate_defrost": { "name": "Climate defrost" },
+      "charge_schedule": { "name": "Charge schedule" },
+      "climate_schedule": { "name": "Climate schedule" }
     },
     "button": {
       "horn_lights": { "name": "Horn & lights" },

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -74,7 +74,9 @@
       "avg_consumption_this_month": { "name": "Avg consumption this month" },
       "climate_temp": { "name": "Climate temperature" },
       "climate_duration": { "name": "Climate duration" },
-      "climate_defrost": { "name": "Climate defrost" }
+      "climate_defrost": { "name": "Climate defrost" },
+      "charge_schedule": { "name": "Charge schedule" },
+      "climate_schedule": { "name": "Climate schedule" }
     },
     "button": {
       "horn_lights": { "name": "Horn & lights" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,17 @@ MOCK_DASHBOARD_DATA = {
     "climate_temp": "normal",
     "climate_duration": 30,
     "climate_defrost": True,
+    "charge_schedule": [
+        {"enabled": True, "days": ["mon", "tue", "wed", "thu", "fri"],
+         "location": "home", "start_time": "22:00", "end_time": "06:00"},
+        {"enabled": False, "days": [], "location": "home",
+         "start_time": "00:00", "end_time": "00:00"},
+    ],
+    "climate_schedule": [
+        {"enabled": True, "days": ["mon", "tue", "wed", "thu", "fri"],
+         "start_time": "07:00"},
+        {"enabled": False, "days": [], "start_time": "00:00"},
+    ],
 }
 
 MOCK_TRIP_DATA = {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -102,6 +102,37 @@ class TestHondaSensor:
         sensor = make_sensor(mock_coordinator, "battery_level")
         assert sensor.native_unit_of_measurement == "%"
 
+    def test_charge_schedule_active_count(self, mock_coordinator):
+        sensor = make_sensor(mock_coordinator, "charge_schedule")
+        assert sensor.native_value == 1
+
+    def test_charge_schedule_attributes(self, mock_coordinator):
+        sensor = make_sensor(mock_coordinator, "charge_schedule")
+        attrs = sensor.extra_state_attributes
+        assert "rules" in attrs
+        assert len(attrs["rules"]) == 2
+        assert attrs["rules"][0]["enabled"] is True
+        assert attrs["rules"][0]["start_time"] == "22:00"
+
+    def test_climate_schedule_active_count(self, mock_coordinator):
+        sensor = make_sensor(mock_coordinator, "climate_schedule")
+        assert sensor.native_value == 1
+
+    def test_climate_schedule_attributes(self, mock_coordinator):
+        sensor = make_sensor(mock_coordinator, "climate_schedule")
+        attrs = sensor.extra_state_attributes
+        assert attrs["rules"][0]["days"] == ["mon", "tue", "wed", "thu", "fri"]
+
+    def test_schedule_no_attributes_for_non_schedule(self, mock_coordinator):
+        sensor = make_sensor(mock_coordinator, "battery_level")
+        assert sensor.extra_state_attributes is None
+
+    def test_schedule_empty_list(self, mock_coordinator):
+        mock_coordinator.data["charge_schedule"] = []
+        sensor = make_sensor(mock_coordinator, "charge_schedule")
+        assert sensor.native_value == 0
+        assert sensor.extra_state_attributes == {"rules": []}
+
 
 class TestHondaTripSensor:
     def test_trips_count(self, mock_trip_coordinator):


### PR DESCRIPTION
## Summary

- **Schedule sensors**: `charge_schedule` and `climate_schedule` — state shows number of active rules, full rule details in attributes
- **Services**: `myhondaplus.set_charge_schedule` (up to 2 rules) and `myhondaplus.set_climate_schedule` (up to 7 rules) for automation control
- Coordinator now fetches schedule data from the dashboard alongside other status

### Service usage example

```yaml
service: myhondaplus.set_charge_schedule
data:
  rules:
    - days: "mon,tue,wed,thu,fri"
      location: "home"
      start_time: "22:00"
      end_time: "06:00"
```

```yaml
service: myhondaplus.set_climate_schedule
data:
  rules:
    - days: "mon,tue,wed,thu,fri"
      start_time: "07:00"
```

## Test plan

- [ ] Verify schedule sensors appear and show active rule count
- [ ] Check sensor attributes contain full schedule rules
- [ ] Test set_charge_schedule service from developer tools
- [ ] Test set_climate_schedule service from developer tools
- [ ] Pass empty rules list to clear schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)