### PR TITLE
Add recurring refresh from car (default 12h)

### DIFF
--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -61,6 +61,13 @@ def _schedule_car_refresh(
     @callback
     def _do_car_refresh(_now) -> None:
         """Refresh from car and reschedule."""
+        if not entry.runtime_data.car_refresh_enabled:
+            # Disabled via switch — just reschedule without refreshing
+            entry.runtime_data.car_refresh_unsub = async_call_later(
+                hass, interval, _do_car_refresh,
+            )
+            return
+
         async def _refresh():
             try:
                 await coordinator.async_refresh_from_car()

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -5,7 +5,12 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN
+from .const import (
+    CONF_CAR_REFRESH_INTERVAL,
+    DEFAULT_CAR_REFRESH_INTERVAL,
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 from .data import MyHondaPlusConfigEntry, MyHondaPlusData
 
@@ -36,9 +41,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
         trip_coordinator=trip_coordinator,
     )
 
+    _schedule_car_refresh(hass, entry)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _register_services(hass)
     return True
+
+
+def _schedule_car_refresh(
+    hass: HomeAssistant, entry: MyHondaPlusConfigEntry,
+) -> None:
+    """Schedule a recurring refresh-from-car if configured."""
+    interval = entry.data.get(CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL)
+    if not interval or interval <= 0:
+        return
+
+    coordinator = entry.runtime_data.coordinator
+
+    @callback
+    def _do_car_refresh(_now) -> None:
+        """Refresh from car and reschedule."""
+        async def _refresh():
+            try:
+                await coordinator.async_refresh_from_car()
+                LOGGER.debug("Scheduled refresh from car completed")
+            except Exception:
+                LOGGER.warning("Scheduled refresh from car failed", exc_info=True)
+            # Delayed coordinator poll to pick up fresh data
+            async_call_later(hass, 30, _schedule_poll)
+
+        hass.async_create_task(_refresh())
+
+    @callback
+    def _schedule_poll(_now) -> None:
+        hass.async_create_task(coordinator.async_request_refresh())
+        # Reschedule next car refresh
+        entry.runtime_data.car_refresh_unsub = async_call_later(
+            hass, interval, _do_car_refresh,
+        )
+
+    entry.runtime_data.car_refresh_unsub = async_call_later(
+        hass, interval, _do_car_refresh,
+    )
 
 
 def _get_coordinator(hass: HomeAssistant) -> HondaDataUpdateCoordinator:
@@ -106,6 +150,9 @@ def _register_services(hass: HomeAssistant) -> None:
 
 async def async_unload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
     """Unload a config entry."""
+    if entry.runtime_data.car_refresh_unsub:
+        entry.runtime_data.car_refresh_unsub()
+        entry.runtime_data.car_refresh_unsub = None
     result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if result and not hass.config_entries.async_entries(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_SET_CHARGE_SCHEDULE)

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -8,6 +8,7 @@ from pymyhondaplus.auth import DeviceKey, HondaAuth
 
 from .const import (
     CONF_ACCESS_TOKEN,
+    CONF_CAR_REFRESH_INTERVAL,
     CONF_DEVICE_KEY_PEM,
     CONF_FUEL_TYPE,
     CONF_PERSONAL_ID,
@@ -15,6 +16,7 @@ from .const import (
     CONF_USER_ID,
     CONF_VEHICLE_NAME,
     CONF_VIN,
+    DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
@@ -24,6 +26,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_EMAIL): str,
     vol.Required(CONF_PASSWORD): str,
     vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
+    vol.Optional(CONF_CAR_REFRESH_INTERVAL, default=DEFAULT_CAR_REFRESH_INTERVAL): int,
 })
 
 STEP_VERIFY_DATA_SCHEMA = vol.Schema({
@@ -38,6 +41,7 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._email = None
         self._password = None
         self._scan_interval = DEFAULT_SCAN_INTERVAL
+        self._car_refresh_interval = DEFAULT_CAR_REFRESH_INTERVAL
         self._device_key = None
         self._auth = None
         self._tokens = None
@@ -51,6 +55,7 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._email = user_input[CONF_EMAIL]
             self._password = user_input[CONF_PASSWORD]
             self._scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+            self._car_refresh_interval = user_input.get(CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL)
 
             self._device_key = DeviceKey()
             self._auth = HondaAuth(device_key=self._device_key)
@@ -221,6 +226,7 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_VIN: vin,
                 CONF_VEHICLE_NAME: vehicle_name,
                 CONF_SCAN_INTERVAL: self._scan_interval,
+                CONF_CAR_REFRESH_INTERVAL: self._car_refresh_interval,
                 CONF_ACCESS_TOKEN: self._tokens["access_token"],
                 CONF_REFRESH_TOKEN: self._tokens["refresh_token"],
                 CONF_USER_ID: user_id,

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -34,8 +34,45 @@ STEP_VERIFY_DATA_SCHEMA = vol.Schema({
 })
 
 
+class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
+    """Options flow for My Honda+."""
+
+    async def async_step_init(self, user_input=None):
+        """Handle options."""
+        if user_input is not None:
+            # Store options in entry data so coordinators pick them up
+            new_data = {**self.config_entry.data, **user_input}
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=new_data,
+            )
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.data.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
+                    ),
+                ): int,
+                vol.Optional(
+                    CONF_CAR_REFRESH_INTERVAL,
+                    default=self.config_entry.data.get(
+                        CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL,
+                    ),
+                ): int,
+            }),
+        )
+
+
 class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return MyHondaPlusOptionsFlow()
 
     def __init__(self):
         self._email = None

--- a/custom_components/myhondaplus/const.py
+++ b/custom_components/myhondaplus/const.py
@@ -14,5 +14,8 @@ CONF_DEVICE_KEY_PEM = "device_key_pem"
 CONF_VEHICLE_NAME = "vehicle_name"
 CONF_FUEL_TYPE = "fuel_type"
 
+CONF_CAR_REFRESH_INTERVAL = "car_refresh_interval"
+
 DEFAULT_SCAN_INTERVAL = 600  # 10 minutes
 DEFAULT_TRIP_INTERVAL = 3600  # 1 hour
+DEFAULT_CAR_REFRESH_INTERVAL = 43200  # 12 hours

--- a/custom_components/myhondaplus/data.py
+++ b/custom_components/myhondaplus/data.py
@@ -21,3 +21,4 @@ class MyHondaPlusData:
     coordinator: HondaDataUpdateCoordinator
     trip_coordinator: HondaTripCoordinator
     car_refresh_unsub: CALLBACK_TYPE | None = field(default=None)
+    car_refresh_enabled: bool = field(default=True)

--- a/custom_components/myhondaplus/data.py
+++ b/custom_components/myhondaplus/data.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE
 
 if TYPE_CHECKING:
     from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
@@ -19,3 +20,4 @@ class MyHondaPlusData:
 
     coordinator: HondaDataUpdateCoordinator
     trip_coordinator: HondaTripCoordinator
+    car_refresh_unsub: CALLBACK_TYPE | None = field(default=None)

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==3.0.0"],
-  "version": "3.1.0-beta.1"
+  "version": "3.1.0-beta.2"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==3.0.0"],
-  "version": "3.0.0"
+  "version": "3.1.0-beta.1"
 }

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -88,7 +88,8 @@
     },
     "switch": {
       "climate": { "name": "Climate" },
-      "charging": { "name": "Charging" }
+      "charging": { "name": "Charging" },
+      "auto_refresh": { "name": "Auto refresh from car" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -41,6 +41,17 @@
       "verification_failed": "Verification failed. Try again."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "My Honda+ settings",
+        "data": {
+          "scan_interval": "Update interval (seconds)",
+          "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "battery_level": { "name": "Battery" },

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -7,7 +7,8 @@
         "data": {
           "email": "Email",
           "password": "Password",
-          "scan_interval": "Update interval (seconds)"
+          "scan_interval": "Update interval (seconds)",
+          "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)"
         }
       },
       "select_vehicle": {

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -25,6 +25,7 @@ async def async_setup_entry(
     async_add_entities([
         HondaClimateSwitch(coordinator, vin, vehicle_name),
         HondaChargeSwitch(coordinator, vin, vehicle_name),
+        HondaAutoRefreshSwitch(coordinator, vin, vehicle_name, entry),
     ])
 
 
@@ -122,3 +123,34 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
         data["charge_status"] = "not_charging"
         self.coordinator.async_set_updated_data(data)
         self._schedule_refresh()
+
+
+class HondaAutoRefreshSwitch(MyHondaPlusEntity, SwitchEntity):
+    """Switch to enable/disable automatic refresh from car."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:refresh-auto"
+    _attr_translation_key = "auto_refresh"
+
+    def __init__(self, coordinator, vin: str, vehicle_name: str, entry) -> None:
+        description = SwitchEntityDescription(
+            key="auto_refresh",
+            translation_key="auto_refresh",
+        )
+        super().__init__(coordinator, description, vin, vehicle_name)
+        self._entry = entry
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if auto refresh is enabled."""
+        return self._entry.runtime_data.car_refresh_enabled
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable auto refresh."""
+        self._entry.runtime_data.car_refresh_enabled = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable auto refresh."""
+        self._entry.runtime_data.car_refresh_enabled = False
+        self.async_write_ha_state()

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -88,7 +88,8 @@
     },
     "switch": {
       "climate": { "name": "Climate" },
-      "charging": { "name": "Charging" }
+      "charging": { "name": "Charging" },
+      "auto_refresh": { "name": "Auto refresh from car" }
     },
     "number": {
       "charge_limit_home": { "name": "Charge limit (home)" },

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -41,6 +41,17 @@
       "verification_failed": "Verification failed. Try again."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "My Honda+ settings",
+        "data": {
+          "scan_interval": "Update interval (seconds)",
+          "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "battery_level": { "name": "Battery" },

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -7,7 +7,8 @@
         "data": {
           "email": "Email",
           "password": "Password",
-          "scan_interval": "Update interval (seconds)"
+          "scan_interval": "Update interval (seconds)",
+          "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)"
         }
       },
       "select_vehicle": {


### PR DESCRIPTION
## Summary

- **Recurring refresh from car** — periodically wakes the TCU to get fresh data (default every 12 hours)
- **Auto refresh switch** — toggle to enable/disable the recurring refresh
- **Options flow** — change scan interval and car refresh interval from Settings > Integrations > Configure (no reconfiguration needed)
- Configurable during setup: set interval in seconds, or 0 to disable
- Self-rescheduling pattern with 30s delayed poll after each refresh
- Timer cancelled on entry unload

## Test plan

- [x] Verify "Refresh from car interval" field appears in config flow
- [x] Set to a short interval (e.g. 120s) and check HA logs for refresh messages
- [x] Set to 0 and verify no recurring refreshes happen
- [x] Toggle the "Auto refresh from car" switch off and verify refreshes stop
- [x] Go to Settings > Integrations > Configure and change intervals
- [x] Restart HA and confirm timer resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)