### PR TITLE
Meet Bronze Integration Quality Scale requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ HACS will track updates automatically, making it easy to upgrade.
 
 </details>
 
+## Removal
+
+To remove the integration cleanly:
+
+1. In Home Assistant, go to **Settings > Devices & Services > Integrations**
+2. Open **My Honda+**
+3. Use the menu and choose **Delete**
+4. Restart Home Assistant if you installed the integration manually and want to remove the files from disk
+
+If you installed through HACS, uninstall it from HACS after removing the integration entry.
+If you installed manually, delete the `custom_components/myhondaplus` directory from your Home Assistant `config/custom_components/` folder.
+
 ## Configuration
 
 The integration will ask for:

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -106,6 +106,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
     """Set up My Honda+ from a config entry."""
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     coordinator = HondaDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.event import async_call_later
 from .const import (
     CONF_CAR_REFRESH_INTERVAL,
     CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_SCAN_INTERVAL,
     DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_LOCATION_REFRESH_INTERVAL,
     DOMAIN,
@@ -101,6 +102,33 @@ SERVICE_CLIMATE_SCHEDULE_SCHEMA = vol.Schema(SERVICE_CLIMATE_SCHEDULE_FIELDS)
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the My Honda+ integration."""
     _register_services(hass)
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
+    """Migrate old config entries to the latest version."""
+    if entry.version == 1:
+        option_keys = (
+            CONF_SCAN_INTERVAL,
+            CONF_CAR_REFRESH_INTERVAL,
+            CONF_LOCATION_REFRESH_INTERVAL,
+        )
+        new_data = dict(entry.data)
+        new_options = dict(entry.options)
+
+        for key in option_keys:
+            if key in new_data:
+                value = new_data.pop(key)
+                if key not in new_options:
+                    new_options[key] = value
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data=new_data,
+            options=new_options,
+            version=2,
+        )
+
     return True
 
 
@@ -307,5 +335,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry)
 
 async def async_reload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -20,6 +20,7 @@ from .const import (
 )
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 from .data import MyHondaPlusConfigEntry, MyHondaPlusData
+from .entry_options import get_entry_value
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.LOCK, Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
@@ -97,6 +98,12 @@ SERVICE_CHARGE_SCHEDULE_SCHEMA = vol.Schema(SERVICE_CHARGE_SCHEDULE_FIELDS)
 SERVICE_CLIMATE_SCHEDULE_SCHEMA = vol.Schema(SERVICE_CLIMATE_SCHEDULE_FIELDS)
 
 
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the My Honda+ integration."""
+    _register_services(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
     """Set up My Honda+ from a config entry."""
     coordinator = HondaDataUpdateCoordinator(hass, entry)
@@ -117,7 +124,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
     _schedule_location_refresh(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    _register_services(hass)
     return True
 
 
@@ -125,7 +131,9 @@ def _schedule_car_refresh(
     hass: HomeAssistant, entry: MyHondaPlusConfigEntry,
 ) -> None:
     """Schedule a recurring refresh-from-car if configured."""
-    interval = entry.data.get(CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL)
+    interval = get_entry_value(
+        entry, CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL,
+    )
     if not interval or interval <= 0:
         return
 
@@ -156,7 +164,9 @@ def _schedule_location_refresh(
     hass: HomeAssistant, entry: MyHondaPlusConfigEntry,
 ) -> None:
     """Schedule a recurring location refresh if configured."""
-    interval = entry.data.get(CONF_LOCATION_REFRESH_INTERVAL, DEFAULT_LOCATION_REFRESH_INTERVAL)
+    interval = get_entry_value(
+        entry, CONF_LOCATION_REFRESH_INTERVAL, DEFAULT_LOCATION_REFRESH_INTERVAL,
+    )
     if not interval or interval <= 0:
         return
 
@@ -290,12 +300,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry)
     if entry.runtime_data.location_refresh_unsub:
         entry.runtime_data.location_refresh_unsub()
         entry.runtime_data.location_refresh_unsub = None
-    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if result and not hass.config_entries.async_entries(DOMAIN):
-        hass.services.async_remove(DOMAIN, SERVICE_SET_CHARGE_SCHEDULE)
-        hass.services.async_remove(DOMAIN, SERVICE_SET_CLIMATE_SCHEDULE)
-        hass.services.async_remove(DOMAIN, SERVICE_CLIMATE_ON)
-    return result
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> None:

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .entry_options import get_entry_value
 
 STEP_USER_DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_EMAIL): str,
@@ -48,10 +49,8 @@ class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle options."""
         if user_input is not None:
-            # Store options in entry data so coordinators pick them up
-            new_data = {**self.config_entry.data, **user_input}
             self.hass.config_entries.async_update_entry(
-                self.config_entry, data=new_data,
+                self.config_entry, options=user_input,
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data={})
@@ -61,20 +60,24 @@ class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
             data_schema=vol.Schema({
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
-                    default=self.config_entry.data.get(
-                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
+                    default=get_entry_value(
+                        self.config_entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
                     ),
                 ): int,
                 vol.Optional(
                     CONF_CAR_REFRESH_INTERVAL,
-                    default=self.config_entry.data.get(
-                        CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL,
+                    default=get_entry_value(
+                        self.config_entry,
+                        CONF_CAR_REFRESH_INTERVAL,
+                        DEFAULT_CAR_REFRESH_INTERVAL,
                     ),
                 ): int,
                 vol.Optional(
                     CONF_LOCATION_REFRESH_INTERVAL,
-                    default=self.config_entry.data.get(
-                        CONF_LOCATION_REFRESH_INTERVAL, DEFAULT_LOCATION_REFRESH_INTERVAL,
+                    default=get_entry_value(
+                        self.config_entry,
+                        CONF_LOCATION_REFRESH_INTERVAL,
+                        DEFAULT_LOCATION_REFRESH_INTERVAL,
                     ),
                 ): int,
             }),
@@ -356,14 +359,16 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_EMAIL: self._email,
                 CONF_VIN: vin,
                 CONF_VEHICLE_NAME: vehicle_name,
-                CONF_SCAN_INTERVAL: self._scan_interval,
-                CONF_CAR_REFRESH_INTERVAL: self._car_refresh_interval,
-                CONF_LOCATION_REFRESH_INTERVAL: self._location_refresh_interval,
                 CONF_ACCESS_TOKEN: self._tokens["access_token"],
                 CONF_REFRESH_TOKEN: self._tokens["refresh_token"],
                 CONF_USER_ID: user_id,
                 CONF_PERSONAL_ID: personal_id,
                 CONF_DEVICE_KEY_PEM: self._device_key.pem_bytes.decode(),
                 CONF_FUEL_TYPE: fuel_type,
+            },
+            options={
+                CONF_SCAN_INTERVAL: self._scan_interval,
+                CONF_CAR_REFRESH_INTERVAL: self._car_refresh_interval,
+                CONF_LOCATION_REFRESH_INTERVAL: self._location_refresh_interval,
             },
         )

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -49,11 +49,7 @@ class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle options."""
         if user_input is not None:
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, options=user_input,
-            )
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            return self.async_create_entry(title="", data={})
+            return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -81,7 +81,7 @@ class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
 
 
 class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     def async_get_options_flow(config_entry):

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -29,6 +29,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .entry_options import get_entry_value
 
 
 def _handle_api_error(
@@ -58,7 +59,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self.api = HondaAPI()
         self._apply_tokens()
 
-        interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        interval = get_entry_value(entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             LOGGER,

--- a/custom_components/myhondaplus/entry_options.py
+++ b/custom_components/myhondaplus/entry_options.py
@@ -4,5 +4,5 @@ from homeassistant.config_entries import ConfigEntry
 
 
 def get_entry_value(entry: ConfigEntry, key: str, default):
-    """Return an entry option, falling back to entry data for older entries."""
-    return entry.options.get(key, entry.data.get(key, default))
+    """Return an entry option."""
+    return entry.options.get(key, default)

--- a/custom_components/myhondaplus/entry_options.py
+++ b/custom_components/myhondaplus/entry_options.py
@@ -1,0 +1,8 @@
+"""Helpers for reading config entry options with data fallback."""
+
+from homeassistant.config_entries import ConfigEntry
+
+
+def get_entry_value(entry: ConfigEntry, key: str, default):
+    """Return an entry option, falling back to entry data for older entries."""
+    return entry.options.get(key, entry.data.get(key, default))

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.1.0"],
-  "version": "4.4.0-beta.2"
+  "version": "4.4.0-beta.3"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.1.0"],
-  "version": "4.3.1"
+  "version": "4.4.0-beta.1"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.1.0"],
-  "version": "4.4.0-beta.1"
+  "version": "4.4.0-beta.2"
 }

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -10,6 +10,13 @@
           "scan_interval": "Update interval (seconds)",
           "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)",
           "location_refresh_interval": "Location refresh interval (seconds, 0 to disable)"
+        },
+        "data_description": {
+          "email": "Email address used to sign in to the My Honda+ app.",
+          "password": "Password for your My Honda+ account.",
+          "scan_interval": "How often Home Assistant polls Honda's cached vehicle data.",
+          "car_refresh_interval": "How often Home Assistant wakes the vehicle for fresh status data. Set to 0 to disable.",
+          "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       },
       "select_vehicle": {
@@ -17,6 +24,9 @@
         "description": "Multiple vehicles found on your account. Select which one to add.",
         "data": {
           "vin": "Vehicle"
+        },
+        "data_description": {
+          "vin": "Choose the vehicle from your My Honda+ account that should be added to Home Assistant."
         }
       },
       "manual_vin": {
@@ -24,6 +34,9 @@
         "description": "Could not auto-detect vehicles. Enter the VIN manually.",
         "data": {
           "vin": "Vehicle Identification Number (VIN)"
+        },
+        "data_description": {
+          "vin": "Enter the VIN exactly as reported by Honda if automatic vehicle detection did not work."
         }
       },
       "verify": {
@@ -31,6 +44,9 @@
         "description": "Honda sent a verification email. Copy the link URL from the email (do NOT click it) and paste it below.",
         "data": {
           "verification_link": "Verification link from email"
+        },
+        "data_description": {
+          "verification_link": "Paste the full verification URL from the Honda email."
         }
       },
       "reauth_confirm": {
@@ -39,6 +55,10 @@
         "data": {
           "email": "Email",
           "password": "Password"
+        },
+        "data_description": {
+          "email": "Email address used to sign in to the My Honda+ app.",
+          "password": "Password for your My Honda+ account."
         }
       }
     },
@@ -61,6 +81,11 @@
           "scan_interval": "Update interval (seconds)",
           "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)",
           "location_refresh_interval": "Location refresh interval (seconds, 0 to disable)"
+        },
+        "data_description": {
+          "scan_interval": "How often Home Assistant polls Honda's cached vehicle data.",
+          "car_refresh_interval": "How often Home Assistant wakes the vehicle for fresh status data. Set to 0 to disable.",
+          "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       }
     }

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -10,6 +10,13 @@
           "scan_interval": "Update interval (seconds)",
           "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)",
           "location_refresh_interval": "Location refresh interval (seconds, 0 to disable)"
+        },
+        "data_description": {
+          "email": "Email address used to sign in to the My Honda+ app.",
+          "password": "Password for your My Honda+ account.",
+          "scan_interval": "How often Home Assistant polls Honda's cached vehicle data.",
+          "car_refresh_interval": "How often Home Assistant wakes the vehicle for fresh status data. Set to 0 to disable.",
+          "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       },
       "select_vehicle": {
@@ -17,6 +24,9 @@
         "description": "Multiple vehicles found on your account. Select which one to add.",
         "data": {
           "vin": "Vehicle"
+        },
+        "data_description": {
+          "vin": "Choose the vehicle from your My Honda+ account that should be added to Home Assistant."
         }
       },
       "manual_vin": {
@@ -24,6 +34,9 @@
         "description": "Could not auto-detect vehicles. Enter the VIN manually.",
         "data": {
           "vin": "Vehicle Identification Number (VIN)"
+        },
+        "data_description": {
+          "vin": "Enter the VIN exactly as reported by Honda if automatic vehicle detection did not work."
         }
       },
       "verify": {
@@ -31,6 +44,9 @@
         "description": "Honda sent a verification email. Copy the link URL from the email (do NOT click it) and paste it below.",
         "data": {
           "verification_link": "Verification link from email"
+        },
+        "data_description": {
+          "verification_link": "Paste the full verification URL from the Honda email."
         }
       },
       "reauth_confirm": {
@@ -39,6 +55,10 @@
         "data": {
           "email": "Email",
           "password": "Password"
+        },
+        "data_description": {
+          "email": "Email address used to sign in to the My Honda+ app.",
+          "password": "Password for your My Honda+ account."
         }
       }
     },
@@ -61,6 +81,11 @@
           "scan_interval": "Update interval (seconds)",
           "car_refresh_interval": "Refresh from car interval (seconds, 0 to disable)",
           "location_refresh_interval": "Location refresh interval (seconds, 0 to disable)"
+        },
+        "data_description": {
+          "scan_interval": "How often Home Assistant polls Honda's cached vehicle data.",
+          "car_refresh_interval": "How often Home Assistant wakes the vehicle for fresh status data. Set to 0 to disable.",
+          "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,17 @@ import pytest
 
 from custom_components.myhondaplus.const import (
     CONF_ACCESS_TOKEN,
+    CONF_CAR_REFRESH_INTERVAL,
     CONF_FUEL_TYPE,
+    CONF_LOCATION_REFRESH_INTERVAL,
     CONF_PERSONAL_ID,
     CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
     CONF_USER_ID,
     CONF_VEHICLE_NAME,
     CONF_VIN,
+    DEFAULT_CAR_REFRESH_INTERVAL,
+    DEFAULT_LOCATION_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -30,8 +34,13 @@ MOCK_ENTRY_DATA = {
     CONF_REFRESH_TOKEN: "fake-refresh-token",
     CONF_USER_ID: "fake-user-id",
     CONF_PERSONAL_ID: "fake-personal-id",
-    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
     CONF_FUEL_TYPE: "E",
+}
+
+MOCK_ENTRY_OPTIONS = {
+    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+    CONF_CAR_REFRESH_INTERVAL: DEFAULT_CAR_REFRESH_INTERVAL,
+    CONF_LOCATION_REFRESH_INTERVAL: DEFAULT_LOCATION_REFRESH_INTERVAL,
 }
 
 MOCK_DASHBOARD_DATA = {
@@ -126,6 +135,7 @@ def mock_config_entry():
     """Return a mocked ConfigEntry."""
     entry = MagicMock()
     entry.data = dict(MOCK_ENTRY_DATA)
+    entry.options = dict(MOCK_ENTRY_OPTIONS)
     entry.entry_id = "test_entry_id"
     entry.domain = DOMAIN
     entry.title = MOCK_VEHICLE_NAME

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -81,11 +81,14 @@ class TestAsyncStepUser:
             })
 
         flow.async_create_entry.assert_called_once()
-        entry_data = flow.async_create_entry.call_args[1]["data"]
+        entry_kwargs = flow.async_create_entry.call_args[1]
+        entry_data = entry_kwargs["data"]
+        entry_options = entry_kwargs["options"]
         assert entry_data[CONF_VIN] == MOCK_VIN
         assert entry_data[CONF_VEHICLE_NAME] == MOCK_VEHICLE_NAME
-        assert entry_data[CONF_SCAN_INTERVAL] == 600
-        assert entry_data[CONF_LOCATION_REFRESH_INTERVAL] == 1800
+        assert CONF_SCAN_INTERVAL not in entry_data
+        assert entry_options[CONF_SCAN_INTERVAL] == 600
+        assert entry_options[CONF_LOCATION_REFRESH_INTERVAL] == 1800
 
     @pytest.mark.asyncio
     async def test_invalid_credentials(self, flow):
@@ -144,6 +147,42 @@ class TestAsyncStepUser:
         # Should show the verify form
         flow.async_show_form.assert_called()
         assert flow.async_show_form.call_args[1]["step_id"] == "verify"
+
+    @pytest.mark.asyncio
+    async def test_device_reset_failure_shows_cannot_connect(self, flow):
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+            mock_auth = MagicMock()
+            mock_auth_cls.return_value = mock_auth
+
+            flow.hass.async_add_executor_job.side_effect = [
+                HondaAuthError(401, "device-authenticator-not-registered"),
+                HondaAuthError(401, "reset failed"),
+            ]
+            await flow.async_step_user({
+                "email": "test@test.com",
+                "password": "pass",
+                "scan_interval": 600,
+                "car_refresh_interval": 43200,
+            })
+
+        errors = flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_unknown_honda_auth_error_shows_cannot_connect(self, flow):
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
+            flow.hass.async_add_executor_job.side_effect = HondaAuthError(500, "something-else")
+            await flow.async_step_user({
+                "email": "test@test.com",
+                "password": "pass",
+                "scan_interval": 600,
+                "car_refresh_interval": 43200,
+            })
+
+        errors = flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "cannot_connect"
 
     @pytest.mark.asyncio
     async def test_generic_exception(self, flow):
@@ -208,6 +247,24 @@ class TestAsyncStepVerify:
 
         flow.async_create_entry.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_valid_link_failed_login_shows_verification_failed(self, flow):
+        flow._email = "test@test.com"
+        flow._password = "pass"
+        flow._auth = MagicMock()
+
+        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+            mock_auth_cls.parse_verify_link_key.return_value = ("key123", "link_type")
+            flow.hass.async_add_executor_job.side_effect = [
+                None,
+                HondaAuthError(401, "invalid-credentials"),
+            ]
+
+            await flow.async_step_verify({"verification_link": "https://honda.com/verify?key=abc"})
+
+        errors = flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "verification_failed"
+
 
 class TestAsyncStepSelectVehicle:
     @pytest.mark.asyncio
@@ -215,6 +272,18 @@ class TestAsyncStepSelectVehicle:
         """Multiple vehicles shows selection form."""
         flow._vehicles = MOCK_VEHICLES_MULTI
         await flow.async_step_select_vehicle(None)
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args[1]["step_id"] == "select_vehicle"
+
+    @pytest.mark.asyncio
+    async def test_multiple_vehicles_without_plate_still_show_selection(self, flow):
+        flow._vehicles = [
+            {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "fuel_type": "E"},
+            {"vin": "ZHWGE11S00LA00002", "name": "", "fuel_type": "E"},
+        ]
+
+        await flow.async_step_select_vehicle(None)
+
         flow.async_show_form.assert_called_once()
         assert flow.async_show_form.call_args[1]["step_id"] == "select_vehicle"
 
@@ -275,9 +344,16 @@ class TestAsyncStepManualVin:
         entry_data = flow.async_create_entry.call_args[1]["data"]
         assert entry_data[CONF_VIN] == "MANUAL12345678901"
         assert entry_data[CONF_VEHICLE_NAME] == ""
+        assert CONF_SCAN_INTERVAL not in entry_data
 
 
 class TestOptionsFlow:
+    def test_config_flow_returns_options_flow(self):
+        assert isinstance(
+            MyHondaPlusConfigFlow.async_get_options_flow(MagicMock()),
+            MyHondaPlusOptionsFlow,
+        )
+
     @pytest.mark.asyncio
     async def test_shows_form_on_first_call(self):
         mock_entry = MagicMock()
@@ -314,6 +390,10 @@ class TestOptionsFlow:
             })
 
         flow.hass.config_entries.async_update_entry.assert_called_once()
+        assert flow.hass.config_entries.async_update_entry.call_args[1]["options"] == {
+            CONF_SCAN_INTERVAL: 300,
+            CONF_CAR_REFRESH_INTERVAL: 7200,
+        }
         flow.hass.config_entries.async_reload.assert_awaited_once()
         flow.async_create_entry.assert_called_once()
 
@@ -380,3 +460,165 @@ class TestReauthFlow:
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "invalid_auth"
+
+    @pytest.mark.asyncio
+    async def test_reauth_device_not_registered_goes_to_verify(self, reauth_flow):
+        reauth_flow.context = {"entry_id": "test_entry"}
+        await reauth_flow.async_step_reauth({})
+
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+            mock_auth = MagicMock()
+            mock_auth_cls.return_value = mock_auth
+            reauth_flow.hass.async_add_executor_job.side_effect = [
+                HondaAuthError(401, "device-authenticator-not-registered"),
+                None,
+            ]
+
+            await reauth_flow.async_step_reauth_confirm({
+                "email": "test@test.com",
+                "password": "newpass",
+            })
+
+        assert reauth_flow.async_show_form.call_args[1]["step_id"] == "verify"
+
+    @pytest.mark.asyncio
+    async def test_reauth_device_reset_failure_shows_cannot_connect(self, reauth_flow):
+        reauth_flow.context = {"entry_id": "test_entry"}
+        await reauth_flow.async_step_reauth({})
+
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+            mock_auth = MagicMock()
+            mock_auth_cls.return_value = mock_auth
+            reauth_flow.hass.async_add_executor_job.side_effect = [
+                HondaAuthError(401, "device-authenticator-not-registered"),
+                HondaAuthError(401, "reset failed"),
+            ]
+
+            await reauth_flow.async_step_reauth_confirm({
+                "email": "test@test.com",
+                "password": "newpass",
+            })
+
+        errors = reauth_flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_reauth_locked_account(self, reauth_flow):
+        reauth_flow.context = {"entry_id": "test_entry"}
+        await reauth_flow.async_step_reauth({})
+
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
+            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(401, "locked-account")
+            await reauth_flow.async_step_reauth_confirm({
+                "email": "test@test.com",
+                "password": "wrong",
+            })
+
+        errors = reauth_flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "account_locked"
+
+    @pytest.mark.asyncio
+    async def test_reauth_unknown_honda_auth_error_shows_cannot_connect(self, reauth_flow):
+        reauth_flow.context = {"entry_id": "test_entry"}
+        await reauth_flow.async_step_reauth({})
+
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
+            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(500, "something-else")
+            await reauth_flow.async_step_reauth_confirm({
+                "email": "test@test.com",
+                "password": "wrong",
+            })
+
+        errors = reauth_flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_reauth_generic_exception_shows_cannot_connect(self, reauth_flow):
+        reauth_flow.context = {"entry_id": "test_entry"}
+        await reauth_flow.async_step_reauth({})
+
+        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
+             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
+            reauth_flow.hass.async_add_executor_job.side_effect = Exception("unexpected")
+            await reauth_flow.async_step_reauth_confirm({
+                "email": "test@test.com",
+                "password": "wrong",
+            })
+
+        errors = reauth_flow.async_show_form.call_args[1]["errors"]
+        assert errors["base"] == "cannot_connect"
+
+
+class TestFetchVehiclesAndCreateEntry:
+    @pytest.mark.asyncio
+    async def test_fetch_vehicles_reauth_short_circuits(self, flow):
+        flow._reauth_entry = MagicMock()
+        flow._tokens = MOCK_TOKENS
+        flow._update_reauth_entry = MagicMock(return_value={"type": "abort"})
+
+        result = await flow._fetch_vehicles_and_continue()
+
+        assert result == {"type": "abort"}
+        flow._update_reauth_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_vehicles_exception_falls_back_to_manual_vin(self, flow):
+        flow._tokens = MOCK_TOKENS
+        flow.async_step_manual_vin = AsyncMock(return_value={"type": "form", "step_id": "manual_vin"})
+
+        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
+             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
+            mock_api = MagicMock()
+            mock_api_cls.return_value = mock_api
+            flow.hass.async_add_executor_job.side_effect = [Exception("boom")]
+
+            result = await flow._fetch_vehicles_and_continue()
+
+        assert result["step_id"] == "manual_vin"
+        flow.async_step_manual_vin.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_vehicles_multiple_entries_goes_to_selection(self, flow):
+        flow._tokens = MOCK_TOKENS
+        flow.async_step_select_vehicle = AsyncMock(return_value={"type": "form", "step_id": "select_vehicle"})
+
+        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
+             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
+            mock_api = MagicMock()
+            mock_api_cls.return_value = mock_api
+            flow.hass.async_add_executor_job.side_effect = [MOCK_VEHICLES_MULTI]
+
+            result = await flow._fetch_vehicles_and_continue()
+
+        assert result["step_id"] == "select_vehicle"
+        flow.async_step_select_vehicle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_entry_personal_id_fallback_and_title_fallback(self, flow):
+        flow._tokens = MOCK_TOKENS
+        flow._email = "test@test.com"
+        flow._scan_interval = DEFAULT_SCAN_INTERVAL
+        flow._car_refresh_interval = DEFAULT_CAR_REFRESH_INTERVAL
+        flow._device_key = MagicMock()
+        flow._device_key.pem_bytes = b"fake-pem"
+        flow._api = None
+
+        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
+             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
+            mock_api = MagicMock()
+            mock_api_cls.return_value = mock_api
+            flow.hass.async_add_executor_job.side_effect = [Exception("boom")]
+
+            await flow._create_entry("VIN12345678901234", "", "")
+
+        flow.async_create_entry.assert_called_once()
+        assert flow.async_create_entry.call_args[1]["title"] == "Honda 901234"
+        assert flow.async_create_entry.call_args[1]["data"]["personal_id"] == ""
+        assert flow.async_create_entry.call_args[1]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -389,13 +389,12 @@ class TestOptionsFlow:
                 CONF_CAR_REFRESH_INTERVAL: 7200,
             })
 
-        flow.hass.config_entries.async_update_entry.assert_called_once()
-        assert flow.hass.config_entries.async_update_entry.call_args[1]["options"] == {
+        flow.hass.config_entries.async_reload.assert_not_called()
+        flow.async_create_entry.assert_called_once()
+        assert flow.async_create_entry.call_args[1]["data"] == {
             CONF_SCAN_INTERVAL: 300,
             CONF_CAR_REFRESH_INTERVAL: 7200,
         }
-        flow.hass.config_entries.async_reload.assert_awaited_once()
-        flow.async_create_entry.assert_called_once()
 
 
 class TestReauthFlow:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,6 +15,7 @@ from custom_components.myhondaplus import (
     SERVICE_SET_CLIMATE_SCHEDULE,
     _get_coordinator,
     _register_services,
+    async_setup,
 )
 from custom_components.myhondaplus.const import DOMAIN
 
@@ -86,6 +87,11 @@ class TestGetCoordinator:
 
 
 class TestRegisterServices:
+    @pytest.mark.asyncio
+    async def test_async_setup_registers_services(self, mock_hass_with_services):
+        assert await async_setup(mock_hass_with_services, {}) is True
+        assert mock_hass_with_services.services.async_register.call_count == 3
+
     def test_registers_three_services(self, mock_hass_with_services):
         _register_services(mock_hass_with_services)
         assert mock_hass_with_services.services.async_register.call_count == 3

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """Tests for __init__.py (services, setup, unload)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
@@ -16,6 +16,7 @@ from custom_components.myhondaplus import (
     _get_coordinator,
     _register_services,
     async_setup,
+    async_setup_entry,
 )
 from custom_components.myhondaplus.const import DOMAIN
 
@@ -112,6 +113,33 @@ class TestRegisterServices:
         _register_services(mock_hass_with_services)
         # Still only 3 calls from the first registration
         assert mock_hass_with_services.services.async_register.call_count == 3
+
+
+class TestSetupEntry:
+    @pytest.mark.asyncio
+    async def test_setup_entry_registers_update_listener(self, mock_hass, mock_entry_with_coordinator):
+        mock_entry_with_coordinator.add_update_listener = MagicMock(return_value="listener")
+        mock_entry_with_coordinator.async_on_unload = MagicMock()
+        mock_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        with patch("custom_components.myhondaplus.HondaDataUpdateCoordinator") as coordinator_cls, \
+             patch("custom_components.myhondaplus.HondaTripCoordinator") as trip_cls, \
+             patch("custom_components.myhondaplus._schedule_car_refresh"), \
+            patch("custom_components.myhondaplus._schedule_location_refresh"):
+            coordinator = MagicMock()
+            coordinator.async_config_entry_first_refresh = AsyncMock()
+            coordinator.api = MagicMock()
+            coordinator._persist_tokens_if_changed = MagicMock()
+            coordinator_cls.return_value = coordinator
+
+            trip = MagicMock()
+            trip.async_config_entry_first_refresh = AsyncMock()
+            trip_cls.return_value = trip
+
+            assert await async_setup_entry(mock_hass, mock_entry_with_coordinator) is True
+
+        mock_entry_with_coordinator.add_update_listener.assert_called_once()
+        mock_entry_with_coordinator.async_on_unload.assert_called_once_with("listener")
 
 
 class TestChargeScheduleSchema:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,10 +15,17 @@ from custom_components.myhondaplus import (
     SERVICE_SET_CLIMATE_SCHEDULE,
     _get_coordinator,
     _register_services,
+    async_migrate_entry,
+    async_reload_entry,
     async_setup,
     async_setup_entry,
 )
-from custom_components.myhondaplus.const import DOMAIN
+from custom_components.myhondaplus.const import (
+    CONF_CAR_REFRESH_INTERVAL,
+    CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_SCAN_INTERVAL,
+    DOMAIN,
+)
 
 
 @pytest.fixture
@@ -115,6 +122,61 @@ class TestRegisterServices:
         assert mock_hass_with_services.services.async_register.call_count == 3
 
 
+class TestMigration:
+    @pytest.mark.asyncio
+    async def test_migrate_v1_moves_interval_settings_to_options(self, mock_hass):
+        entry = MagicMock()
+        entry.version = 1
+        entry.data = {
+            CONF_SCAN_INTERVAL: 300,
+            CONF_CAR_REFRESH_INTERVAL: 7200,
+            CONF_LOCATION_REFRESH_INTERVAL: 1800,
+            "vin": "VIN123",
+        }
+        entry.options = {}
+
+        assert await async_migrate_entry(mock_hass, entry) is True
+
+        mock_hass.config_entries.async_update_entry.assert_called_once()
+        kwargs = mock_hass.config_entries.async_update_entry.call_args.kwargs
+        assert kwargs["data"] == {"vin": "VIN123"}
+        assert kwargs["options"] == {
+            CONF_SCAN_INTERVAL: 300,
+            CONF_CAR_REFRESH_INTERVAL: 7200,
+            CONF_LOCATION_REFRESH_INTERVAL: 1800,
+        }
+        assert kwargs["version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_migrate_v1_preserves_existing_options(self, mock_hass):
+        entry = MagicMock()
+        entry.version = 1
+        entry.data = {
+            CONF_SCAN_INTERVAL: 300,
+            CONF_CAR_REFRESH_INTERVAL: 7200,
+        }
+        entry.options = {CONF_SCAN_INTERVAL: 600}
+
+        assert await async_migrate_entry(mock_hass, entry) is True
+
+        kwargs = mock_hass.config_entries.async_update_entry.call_args.kwargs
+        assert kwargs["data"] == {}
+        assert kwargs["options"] == {
+            CONF_SCAN_INTERVAL: 600,
+            CONF_CAR_REFRESH_INTERVAL: 7200,
+        }
+
+    @pytest.mark.asyncio
+    async def test_migrate_current_version_noop(self, mock_hass):
+        entry = MagicMock()
+        entry.version = 2
+        entry.data = {}
+        entry.options = {}
+
+        assert await async_migrate_entry(mock_hass, entry) is True
+        mock_hass.config_entries.async_update_entry.assert_not_called()
+
+
 class TestSetupEntry:
     @pytest.mark.asyncio
     async def test_setup_entry_registers_update_listener(self, mock_hass, mock_entry_with_coordinator):
@@ -140,6 +202,16 @@ class TestSetupEntry:
 
         mock_entry_with_coordinator.add_update_listener.assert_called_once()
         mock_entry_with_coordinator.async_on_unload.assert_called_once_with("listener")
+
+    @pytest.mark.asyncio
+    async def test_reload_entry_uses_config_entries_reload(self, mock_hass):
+        entry = MagicMock()
+        entry.entry_id = "entry_1"
+        mock_hass.config_entries.async_reload = AsyncMock()
+
+        await async_reload_entry(mock_hass, entry)
+
+        mock_hass.config_entries.async_reload.assert_awaited_once_with("entry_1")
 
 
 class TestChargeScheduleSchema:


### PR DESCRIPTION
## Summary

- **action-setup**: Move service registration from `async_setup_entry` to `async_setup`; remove service cleanup from `async_unload_entry`
- **config-flow**: Store interval settings in `ConfigEntry.options` instead of `.data`; add `data_description` to all config flow steps
- **config-flow**: Config entry migration v1→v2 moves intervals from `data` to `options` on first load
- **config-flow**: Options flow uses `async_create_entry(data=)` to persist options; update listener triggers reload
- **docs-removal-instructions**: Add removal section to README
- **config-flow-test-coverage**: Expand tests for all config flow error/edge-case paths (device reset, reauth, vehicle selection, options flow, migration)

## Test plan

- [x] Run `pytest` — 212 tests pass
- [x] Existing install: migration moves intervals from `data` to `options`, version bumped to 2
- [x] Options flow: changes saved to `options` dict (verified via diagnostics)
- [ ] Fresh install: verify intervals are stored in `options`, not `data`
- [x] Config flow: verify `data_description` hints appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)