### PR TITLE
Enhance error handling and update dependency to pymyhondaplus 5.2.2

### DIFF
--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -127,17 +127,31 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._log_recovered_once()
         return data
 
-    def _fetch_data_fresh(self) -> dict:
-        dashboard = self.api.get_dashboard(self.vin, fresh=True)
-        data = parse_ev_status(dashboard)
-        data["charge_schedule"] = parse_charge_schedule(dashboard)
-        data["climate_schedule"] = parse_climate_schedule(dashboard)
-        return data
+    def _refresh_from_car(self):
+        """Request fresh data from the car and return the command result."""
+        return self.api.refresh_dashboard(self.vin)
 
     async def async_refresh_from_car(self) -> None:
         """Request fresh data from the car (wakes TCU, polls until done)."""
         try:
-            data = await self.hass.async_add_executor_job(self._fetch_data_fresh)
+            result = await self.hass.async_add_executor_job(self._refresh_from_car)
+            if not result.success:
+                if result.timed_out:
+                    LOGGER.warning(
+                        "Dashboard refresh timed out waiting for the car to respond (status=%s, reason=%s)",
+                        result.status,
+                        result.reason,
+                    )
+                else:
+                    LOGGER.warning(
+                        "Dashboard refresh did not succeed (status=%s, reason=%s)",
+                        result.status,
+                        result.reason,
+                    )
+                raise HomeAssistantError(
+                    "Unable to refresh data from vehicle"
+                )
+            data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
             _handle_api_error(err, self._persist_tokens_if_changed)
             LOGGER.error("Dashboard refresh failed: %s", err)
@@ -159,7 +173,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._persist_tokens_if_changed()
         return result
 
-    async def async_send_command_and_wait(self, func, *args, timeout: int = 60) -> bool:
+    async def async_send_command_and_wait(self, func, *args, timeout: int = 90) -> bool:
         """Send a command and wait for confirmation. Raises on send failure."""
         command_id = await self.async_send_command(func, *args)
         if not command_id:
@@ -168,7 +182,20 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             self.api.wait_for_command, command_id, timeout,
         )
         if not result.success:
-            LOGGER.warning("Command did not succeed (id=%s, status=%s)", command_id, result.status)
+            if result.timed_out:
+                LOGGER.warning(
+                    "Command timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
+                    command_id,
+                    result.status,
+                    result.reason,
+                )
+            else:
+                LOGGER.warning(
+                    "Command did not succeed (id=%s, status=%s, reason=%s)",
+                    command_id,
+                    result.status,
+                    result.reason,
+                )
         return result.success
 
     async def async_refresh_location(self) -> None:
@@ -178,13 +205,23 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                 self.api.request_car_location, self.vin,
             )
             result = await self.hass.async_add_executor_job(
-                self.api.wait_for_command, command_id,
+                self.api.wait_for_command, command_id, 90,
             )
             if not result.success:
-                LOGGER.warning(
-                    "Location refresh command did not succeed (id=%s, status=%s)",
-                    command_id, result.status,
-                )
+                if result.timed_out:
+                    LOGGER.warning(
+                        "Location refresh timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
+                        command_id,
+                        result.status,
+                        result.reason,
+                    )
+                else:
+                    LOGGER.warning(
+                        "Location refresh command did not succeed (id=%s, status=%s, reason=%s)",
+                        command_id,
+                        result.status,
+                        result.reason,
+                    )
                 raise HomeAssistantError(
                     "Unable to refresh location from vehicle"
                 )

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -2,6 +2,9 @@
 
 from datetime import timedelta
 
+from homeassistant.components.persistent_notification import (
+    async_create as pn_async_create,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
@@ -23,6 +26,7 @@ from .const import (
     CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
     CONF_USER_ID,
+    CONF_VEHICLE_NAME,
     CONF_VIN,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TRIP_INTERVAL,
@@ -55,6 +59,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.entry = entry
         self.vin: str = entry.data[CONF_VIN]
+        self._vehicle_name: str = entry.data.get(CONF_VEHICLE_NAME, "")
         self.api = HondaAPI()
         self._service_available = True
         self._apply_tokens()
@@ -142,6 +147,12 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                         result.status,
                         result.reason,
                     )
+                    pn_async_create(
+                        self.hass,
+                        f"Dashboard refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                        title="My Honda+",
+                        notification_id=f"{DOMAIN}_refresh_timeout",
+                    )
                 else:
                     LOGGER.warning(
                         "Dashboard refresh did not succeed (status=%s, reason=%s)",
@@ -189,6 +200,12 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                     result.status,
                     result.reason,
                 )
+                pn_async_create(
+                    self.hass,
+                    f"A command for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                    title="My Honda+",
+                    notification_id=f"{DOMAIN}_command_timeout",
+                )
             else:
                 LOGGER.warning(
                     "Command did not succeed (id=%s, status=%s, reason=%s)",
@@ -214,6 +231,12 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                         command_id,
                         result.status,
                         result.reason,
+                    )
+                    pn_async_create(
+                        self.hass,
+                        f"Location refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                        title="My Honda+",
+                        notification_id=f"{DOMAIN}_location_timeout",
                     )
                 else:
                     LOGGER.warning(

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.1.0"],
-  "version": "4.4.0-beta.4"
+  "requirements": ["pymyhondaplus==5.2.2"],
+  "version": "4.4.0-beta.5"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.2.2"],
-  "version": "4.4.0-beta.5"
+  "version": "4.4.0-beta.6"
 }

--- a/custom_components/myhondaplus/number.py
+++ b/custom_components/myhondaplus/number.py
@@ -75,7 +75,6 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         data = self.coordinator.data or {}
-        prev = data.get(self.entity_description.key)
         home = data.get("charge_limit_home", 80)
         away = data.get("charge_limit_away", 90)
 
@@ -84,13 +83,10 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
         else:
             away = int(value)
 
-        new_data = dict(self.coordinator.data)
-        new_data[self.entity_description.key] = int(value)
-        self.coordinator.async_set_updated_data(new_data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_charge_limit, self._vin, home, away,
         )
-        if not confirmed:
+        if confirmed:
             new_data = dict(self.coordinator.data)
-            new_data[self.entity_description.key] = prev
+            new_data[self.entity_description.key] = int(value)
             self.coordinator.async_set_updated_data(new_data)

--- a/custom_components/myhondaplus/select.py
+++ b/custom_components/myhondaplus/select.py
@@ -55,21 +55,17 @@ class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update climate temperature setting on the vehicle."""
         data = self.coordinator.data or {}
-        prev = data.get("climate_temp")
         duration = data.get("climate_duration", 30)
         if duration not in (10, 20, 30):
             duration = 30
         defrost = data.get("climate_defrost", True)
-        new_data = dict(self.coordinator.data)
-        new_data["climate_temp"] = option
-        self.coordinator.async_set_updated_data(new_data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
             self._vin, option, duration, defrost,
         )
-        if not confirmed:
+        if confirmed:
             new_data = dict(self.coordinator.data)
-            new_data["climate_temp"] = prev
+            new_data["climate_temp"] = option
             self.coordinator.async_set_updated_data(new_data)
 
 
@@ -98,20 +94,16 @@ class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update climate duration setting on the vehicle."""
         data = self.coordinator.data or {}
-        prev = data.get("climate_duration")
         temp = data.get("climate_temp", "normal")
         if temp not in CLIMATE_TEMP_OPTIONS:
             temp = "normal"
         defrost = data.get("climate_defrost", True)
         duration = int(option)
-        new_data = dict(self.coordinator.data)
-        new_data["climate_duration"] = duration
-        self.coordinator.async_set_updated_data(new_data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
             self._vin, temp, duration, defrost,
         )
-        if not confirmed:
+        if confirmed:
             new_data = dict(self.coordinator.data)
-            new_data["climate_duration"] = prev
+            new_data["climate_duration"] = duration
             self.coordinator.async_set_updated_data(new_data)

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -57,30 +57,22 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Start climate pre-conditioning."""
-        data = dict(self.coordinator.data)
-        prev = data.get("climate_active")
-        data["climate_active"] = True
-        self.coordinator.async_set_updated_data(data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.remote_climate_start, self._vin,
         )
-        if not confirmed:
+        if confirmed:
             data = dict(self.coordinator.data)
-            data["climate_active"] = prev
+            data["climate_active"] = True
             self.coordinator.async_set_updated_data(data)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
-        data = dict(self.coordinator.data)
-        prev = data.get("climate_active")
-        data["climate_active"] = False
-        self.coordinator.async_set_updated_data(data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.remote_climate_stop, self._vin,
         )
-        if not confirmed:
+        if confirmed:
             data = dict(self.coordinator.data)
-            data["climate_active"] = prev
+            data["climate_active"] = False
             self.coordinator.async_set_updated_data(data)
 
 
@@ -112,30 +104,22 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Start charging."""
-        data = dict(self.coordinator.data)
-        prev = data.get("charge_status")
-        data["charge_status"] = "charging"
-        self.coordinator.async_set_updated_data(data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.remote_charge_start, self._vin,
         )
-        if not confirmed:
+        if confirmed:
             data = dict(self.coordinator.data)
-            data["charge_status"] = prev
+            data["charge_status"] = "charging"
             self.coordinator.async_set_updated_data(data)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
-        data = dict(self.coordinator.data)
-        prev = data.get("charge_status")
-        data["charge_status"] = "not_charging"
-        self.coordinator.async_set_updated_data(data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.remote_charge_stop, self._vin,
         )
-        if not confirmed:
+        if confirmed:
             data = dict(self.coordinator.data)
-            data["charge_status"] = prev
+            data["charge_status"] = "not_charging"
             self.coordinator.async_set_updated_data(data)
 
 
@@ -169,23 +153,19 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
 
     async def _set_defrost(self, defrost: bool) -> None:
         data = self.coordinator.data or {}
-        prev = data.get("climate_defrost")
         temp = data.get("climate_temp", "normal")
         if temp not in ("cooler", "normal", "hotter"):
             temp = "normal"
         duration = data.get("climate_duration", 30)
         if duration not in (10, 20, 30):
             duration = 30
-        new_data = dict(self.coordinator.data)
-        new_data["climate_defrost"] = defrost
-        self.coordinator.async_set_updated_data(new_data)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
             self._vin, temp, duration, defrost,
         )
-        if not confirmed:
+        if confirmed:
             new_data = dict(self.coordinator.data)
-            new_data["climate_defrost"] = prev
+            new_data["climate_defrost"] = defrost
             self.coordinator.async_set_updated_data(new_data)
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -137,9 +137,18 @@ class TestHondaDataUpdateCoordinator:
 
     @pytest.mark.asyncio
     async def test_refresh_from_car_success(self, coordinator):
-        coordinator.hass.async_add_executor_job.return_value = dict(MOCK_DASHBOARD_DATA)
+        coordinator.hass.async_add_executor_job.side_effect = [
+            SimpleNamespace(success=True, status="success", timed_out=False, reason=None),
+            dict(MOCK_DASHBOARD_DATA),
+        ]
         await coordinator.async_refresh_from_car()
         coordinator.async_set_updated_data.assert_called_once()
+        assert coordinator.hass.async_add_executor_job.await_args_list[0].args == (
+            coordinator._refresh_from_car,
+        )
+        assert coordinator.hass.async_add_executor_job.await_args_list[1].args == (
+            coordinator._fetch_data,
+        )
 
     @pytest.mark.asyncio
     async def test_refresh_from_car_401(self, coordinator):
@@ -152,6 +161,23 @@ class TestHondaDataUpdateCoordinator:
         coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
         with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
             await coordinator.async_refresh_from_car()
+
+    @pytest.mark.asyncio
+    async def test_refresh_from_car_timeout_raises(self, coordinator):
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=False, status="pending", timed_out=True, reason=None,
+        )
+
+        with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
+            with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
+                await coordinator.async_refresh_from_car()
+
+        coordinator.async_set_updated_data.assert_not_called()
+        logger.warning.assert_called_once_with(
+            "Dashboard refresh timed out waiting for the car to respond (status=%s, reason=%s)",
+            "pending",
+            None,
+        )
 
     @pytest.mark.asyncio
     async def test_send_command_success(self, coordinator):
@@ -176,10 +202,42 @@ class TestHondaDataUpdateCoordinator:
             await coordinator.async_send_command(func)
 
     @pytest.mark.asyncio
+    async def test_send_command_and_wait_uses_90_second_timeout(self, coordinator):
+        func = MagicMock()
+        coordinator.async_send_command = AsyncMock(return_value="cmd-123")
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=True, status="success", timed_out=False, reason=None,
+        )
+
+        assert await coordinator.async_send_command_and_wait(func, "arg1") is True
+
+        coordinator.hass.async_add_executor_job.assert_awaited_once_with(
+            coordinator.api.wait_for_command, "cmd-123", 90,
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_command_and_wait_timeout_logs_specific_message(self, coordinator):
+        func = MagicMock()
+        coordinator.async_send_command = AsyncMock(return_value="cmd-123")
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=False, status="timeout", timed_out=True, reason=None,
+        )
+
+        with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
+            assert await coordinator.async_send_command_and_wait(func, "arg1") is False
+
+        logger.warning.assert_called_once_with(
+            "Command timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
+            "cmd-123",
+            "timeout",
+            None,
+        )
+
+    @pytest.mark.asyncio
     async def test_refresh_location_success(self, coordinator):
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.side_effect = [
-            SimpleNamespace(success=True, status="success"),
+            SimpleNamespace(success=True, status="success", timed_out=False, reason=None),
             dict(MOCK_DASHBOARD_DATA),
         ]
 
@@ -189,7 +247,7 @@ class TestHondaDataUpdateCoordinator:
             coordinator.api.request_car_location, MOCK_VIN,
         )
         assert coordinator.hass.async_add_executor_job.await_args_list[0].args == (
-            coordinator.api.wait_for_command, "cmd-123",
+            coordinator.api.wait_for_command, "cmd-123", 90,
         )
         assert coordinator.hass.async_add_executor_job.await_args_list[1].args == (
             coordinator._fetch_data,
@@ -200,15 +258,22 @@ class TestHondaDataUpdateCoordinator:
     async def test_refresh_location_command_failure_raises(self, coordinator):
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="timeout",
+            success=False, status="timeout", timed_out=True, reason=None,
         )
 
-        with pytest.raises(HomeAssistantError, match="Unable to refresh location"):
-            await coordinator.async_refresh_location()
+        with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
+            with pytest.raises(HomeAssistantError, match="Unable to refresh location"):
+                await coordinator.async_refresh_location()
 
         coordinator.async_set_updated_data.assert_not_called()
         coordinator.hass.async_add_executor_job.assert_awaited_once_with(
-            coordinator.api.wait_for_command, "cmd-123",
+            coordinator.api.wait_for_command, "cmd-123", 90,
+        )
+        logger.warning.assert_called_once_with(
+            "Location refresh timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
+            "cmd-123",
+            "timeout",
+            None,
         )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,7 +14,7 @@ from custom_components.myhondaplus.coordinator import (
     HondaTripCoordinator,
 )
 
-from .conftest import MOCK_DASHBOARD_DATA, MOCK_ENTRY_DATA, MOCK_VIN
+from .conftest import MOCK_DASHBOARD_DATA, MOCK_ENTRY_DATA, MOCK_VEHICLE_NAME, MOCK_VIN
 
 Tokens = namedtuple("Tokens", ["access_token", "refresh_token"])
 
@@ -46,6 +46,7 @@ def coordinator(mock_hass, mock_entry):
         coord.data = dict(MOCK_DASHBOARD_DATA)
         coord.logger = MagicMock()
         coord._service_available = True
+        coord._vehicle_name = MOCK_VEHICLE_NAME
         coord.async_set_updated_data = MagicMock()
         return coord
 
@@ -169,8 +170,9 @@ class TestHondaDataUpdateCoordinator:
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
-                await coordinator.async_refresh_from_car()
+            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+                with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
+                    await coordinator.async_refresh_from_car()
 
         coordinator.async_set_updated_data.assert_not_called()
         logger.warning.assert_called_once_with(
@@ -178,6 +180,24 @@ class TestHondaDataUpdateCoordinator:
             "pending",
             None,
         )
+        pn_create.assert_called_once_with(
+            coordinator.hass,
+            f"Dashboard refresh for {MOCK_VEHICLE_NAME} timed out waiting for the car to respond.",
+            title="My Honda+",
+            notification_id="myhondaplus_refresh_timeout",
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_from_car_failure_no_notification(self, coordinator):
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=False, status="failed", timed_out=False, reason="error",
+        )
+
+        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            with pytest.raises(HomeAssistantError, match="Unable to refresh data"):
+                await coordinator.async_refresh_from_car()
+
+        pn_create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_command_success(self, coordinator):
@@ -216,7 +236,7 @@ class TestHondaDataUpdateCoordinator:
         )
 
     @pytest.mark.asyncio
-    async def test_send_command_and_wait_timeout_logs_specific_message(self, coordinator):
+    async def test_send_command_and_wait_timeout_logs_and_notifies(self, coordinator):
         func = MagicMock()
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
@@ -224,7 +244,8 @@ class TestHondaDataUpdateCoordinator:
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            assert await coordinator.async_send_command_and_wait(func, "arg1") is False
+            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+                assert await coordinator.async_send_command_and_wait(func, "arg1") is False
 
         logger.warning.assert_called_once_with(
             "Command timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
@@ -232,6 +253,25 @@ class TestHondaDataUpdateCoordinator:
             "timeout",
             None,
         )
+        pn_create.assert_called_once_with(
+            coordinator.hass,
+            f"A command for {MOCK_VEHICLE_NAME} timed out waiting for the car to respond.",
+            title="My Honda+",
+            notification_id="myhondaplus_command_timeout",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_command_and_wait_failure_no_notification(self, coordinator):
+        func = MagicMock()
+        coordinator.async_send_command = AsyncMock(return_value="cmd-123")
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=False, status="failed", timed_out=False, reason="error",
+        )
+
+        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            assert await coordinator.async_send_command_and_wait(func, "arg1") is False
+
+        pn_create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_refresh_location_success(self, coordinator):
@@ -262,8 +302,9 @@ class TestHondaDataUpdateCoordinator:
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            with pytest.raises(HomeAssistantError, match="Unable to refresh location"):
-                await coordinator.async_refresh_location()
+            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+                with pytest.raises(HomeAssistantError, match="Unable to refresh location"):
+                    await coordinator.async_refresh_location()
 
         coordinator.async_set_updated_data.assert_not_called()
         coordinator.hass.async_add_executor_job.assert_awaited_once_with(
@@ -274,6 +315,12 @@ class TestHondaDataUpdateCoordinator:
             "cmd-123",
             "timeout",
             None,
+        )
+        pn_create.assert_called_once_with(
+            coordinator.hass,
+            f"Location refresh for {MOCK_VEHICLE_NAME} timed out waiting for the car to respond.",
+            title="My Honda+",
+            notification_id="myhondaplus_location_timeout",
         )
 
 

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -445,7 +445,9 @@ class TestCoordinatorCoverage:
         coord.hass = MagicMock()
         coord.api = MagicMock()
         coord.hass.async_add_executor_job = AsyncMock(
-            return_value=SimpleNamespace(success=False, status="timeout"),
+            return_value=SimpleNamespace(
+                success=False, status="timeout", timed_out=True, reason=None,
+            ),
         )
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
             result = await HondaDataUpdateCoordinator.async_send_command_and_wait(coord, MagicMock())
@@ -479,7 +481,7 @@ class TestCoordinatorCoverage:
         HondaDataUpdateCoordinator._persist_tokens_if_changed(coord)
         coord.hass.config_entries.async_update_entry.assert_called_once()
 
-    def test_fetch_data_and_fresh(self):
+    def test_fetch_data_and_refresh_command(self):
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.vin = MOCK_VIN
         coord.api = MagicMock()
@@ -487,9 +489,9 @@ class TestCoordinatorCoverage:
              patch("custom_components.myhondaplus.coordinator.parse_charge_schedule", return_value=["a"]), \
              patch("custom_components.myhondaplus.coordinator.parse_climate_schedule", return_value=["b"]):
             coord.api.get_dashboard_cached.return_value = {"dash": 1}
-            coord.api.get_dashboard.return_value = {"dash": 2}
+            coord.api.refresh_dashboard.return_value = SimpleNamespace(success=True)
             assert HondaDataUpdateCoordinator._fetch_data(coord) == {"x": 1, "charge_schedule": ["a"], "climate_schedule": ["b"]}
-            assert HondaDataUpdateCoordinator._fetch_data_fresh(coord) == {"x": 1, "charge_schedule": ["a"], "climate_schedule": ["b"]}
+            assert HondaDataUpdateCoordinator._refresh_from_car(coord).success is True
 
     def test_trip_fetch_data_uses_main_coordinator_distance(self):
         coord = HondaTripCoordinator.__new__(HondaTripCoordinator)

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -301,7 +301,7 @@ class TestPlatformSetupCoverage:
 
 class TestNumberCoverage:
     @pytest.mark.asyncio
-    async def test_set_limit_reverts_on_failure(self):
+    async def test_set_limit_no_update_on_failure(self):
         class FakeCoordinator:
             def __init__(self) -> None:
                 self.data = dict(MOCK_DASHBOARD_DATA)
@@ -318,7 +318,7 @@ class TestNumberCoverage:
             coordinator, description, MOCK_VIN, MOCK_VEHICLE_NAME,
         )
         await number.async_set_native_value(85)
-        assert coordinator.async_set_updated_data.call_count == 2
+        coordinator.async_set_updated_data.assert_not_called()
 
 
 class TestSelectCoverage:
@@ -355,12 +355,12 @@ class TestSelectCoverage:
 
 class TestSwitchCoverage:
     @pytest.mark.asyncio
-    async def test_climate_switch_reverts_on_failure(self, mock_coordinator):
+    async def test_climate_switch_no_update_on_failure(self, mock_coordinator):
         mock_coordinator.async_send_command_and_wait.return_value = False
         entity = HondaClimateSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
         entity.hass = _make_hass_mock()
         await entity.async_turn_on()
-        assert mock_coordinator.async_set_updated_data.call_count == 2
+        mock_coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_charge_switch_bool_and_failure_paths(self, mock_coordinator):
@@ -370,10 +370,10 @@ class TestSwitchCoverage:
         assert entity.is_on is True
         mock_coordinator.async_send_command_and_wait.return_value = False
         await entity.async_turn_off()
-        assert mock_coordinator.async_set_updated_data.call_count == 2
+        mock_coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_defrost_switch_defaults_and_reverts(self, mock_coordinator):
+    async def test_defrost_switch_defaults_and_no_update_on_failure(self, mock_coordinator):
         mock_coordinator.data["climate_temp"] = "bad"
         mock_coordinator.data["climate_duration"] = 99
         mock_coordinator.async_send_command_and_wait.return_value = False
@@ -383,7 +383,7 @@ class TestSwitchCoverage:
         args = mock_coordinator.async_send_command_and_wait.call_args[0]
         assert args[2] == "normal"
         assert args[3] == 30
-        assert mock_coordinator.async_set_updated_data.call_count == 2
+        mock_coordinator.async_set_updated_data.assert_not_called()
 
     def test_auto_refresh_switch(self, mock_coordinator):
         entry = MagicMock()
@@ -444,13 +444,15 @@ class TestCoordinatorCoverage:
         coord.async_send_command = AsyncMock(return_value="cmd")
         coord.hass = MagicMock()
         coord.api = MagicMock()
+        coord._vehicle_name = MOCK_VEHICLE_NAME
         coord.hass.async_add_executor_job = AsyncMock(
             return_value=SimpleNamespace(
                 success=False, status="timeout", timed_out=True, reason=None,
             ),
         )
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            result = await HondaDataUpdateCoordinator.async_send_command_and_wait(coord, MagicMock())
+            with patch("custom_components.myhondaplus.coordinator.pn_async_create"):
+                result = await HondaDataUpdateCoordinator.async_send_command_and_wait(coord, MagicMock())
         assert result is False
         logger.warning.assert_called_once()
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -83,9 +83,24 @@ class TestDoorLock:
 
     @pytest.mark.asyncio
     async def test_unlock_does_not_mutate_original(self, door_lock):
-        """Ensure optimistic update creates a copy."""
+        """Ensure confirmed update creates a copy."""
         original_data = door_lock.coordinator.data
         original_locked = original_data["doors_locked"]
         await door_lock.async_unlock()
         # Original data should not have been changed
         assert original_data["doors_locked"] == original_locked
+
+    @pytest.mark.asyncio
+    async def test_lock_no_update_on_failure(self, door_lock):
+        door_lock.coordinator.async_send_command_and_wait.return_value = False
+        await door_lock.async_lock()
+        door_lock.coordinator.async_set_updated_data.assert_not_called()
+        # Pending flags should still be cleared
+        assert door_lock._attr_is_locking is False
+
+    @pytest.mark.asyncio
+    async def test_unlock_no_update_on_failure(self, door_lock):
+        door_lock.coordinator.async_send_command_and_wait.return_value = False
+        await door_lock.async_unlock()
+        door_lock.coordinator.async_set_updated_data.assert_not_called()
+        assert door_lock._attr_is_unlocking is False

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -46,10 +46,17 @@ class TestChargeLimitNumber:
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(
             mock_coordinator.api.set_charge_limit, MOCK_VIN, 85, 100,
         )
-        # Optimistic update via async_set_updated_data
+        # Confirmed update via async_set_updated_data
         mock_coordinator.async_set_updated_data.assert_called_once()
         data = mock_coordinator.async_set_updated_data.call_args[0][0]
         assert data["charge_limit_home"] == 85
+
+    @pytest.mark.asyncio
+    async def test_set_home_limit_no_update_on_failure(self, mock_coordinator):
+        mock_coordinator.async_send_command_and_wait.return_value = False
+        number = make_number(mock_coordinator, "charge_limit_home")
+        await number.async_set_native_value(85.0)
+        mock_coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_set_away_limit(self, mock_coordinator):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -66,13 +66,10 @@ class TestClimateTempSelect:
         assert updated["climate_temp"] == "cooler"
 
     @pytest.mark.asyncio
-    async def test_select_option_reverts_on_timeout(self, temp_select):
+    async def test_select_option_no_update_on_failure(self, temp_select):
         temp_select.coordinator.async_send_command_and_wait.return_value = False
         await temp_select.async_select_option("hotter")
-        # Optimistic set, then revert
-        assert temp_select.coordinator.async_set_updated_data.call_count == 2
-        reverted = temp_select.coordinator.async_set_updated_data.call_args[0][0]
-        assert reverted["climate_temp"] == "normal"
+        temp_select.coordinator.async_set_updated_data.assert_not_called()
 
 
 class TestClimateDurationSelect:
@@ -111,9 +108,7 @@ class TestClimateDurationSelect:
         assert updated["climate_duration"] == 10
 
     @pytest.mark.asyncio
-    async def test_select_option_reverts_on_timeout(self, duration_select):
+    async def test_select_option_no_update_on_failure(self, duration_select):
         duration_select.coordinator.async_send_command_and_wait.return_value = False
         await duration_select.async_select_option("20")
-        assert duration_select.coordinator.async_set_updated_data.call_count == 2
-        reverted = duration_select.coordinator.async_set_updated_data.call_args[0][0]
-        assert reverted["climate_duration"] == 30
+        duration_select.coordinator.async_set_updated_data.assert_not_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -79,12 +79,16 @@ class TestClimateSwitch:
         assert data["climate_active"] is False
 
     @pytest.mark.asyncio
-    async def test_turn_off_reverts_on_failure(self, climate_switch):
+    async def test_turn_on_no_update_on_failure(self, climate_switch):
+        climate_switch.coordinator.async_send_command_and_wait.return_value = False
+        await climate_switch.async_turn_on()
+        climate_switch.coordinator.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_no_update_on_failure(self, climate_switch):
         climate_switch.coordinator.async_send_command_and_wait.return_value = False
         await climate_switch.async_turn_off()
-        assert climate_switch.coordinator.async_set_updated_data.call_count == 2
-        reverted = climate_switch.coordinator.async_set_updated_data.call_args[0][0]
-        assert reverted["climate_active"] is False
+        climate_switch.coordinator.async_set_updated_data.assert_not_called()
 
 
 class TestChargeSwitch:
@@ -145,17 +149,23 @@ class TestChargeSwitch:
 
     @pytest.mark.asyncio
     async def test_turn_on_does_not_mutate_original(self, charge_switch):
-        """Ensure optimistic update creates a copy, not mutating coordinator.data."""
+        """Ensure confirmed update creates a copy, not mutating coordinator.data."""
         original_data = charge_switch.coordinator.data
         await charge_switch.async_turn_on()
         # The original dict should not have been modified
         assert original_data["charge_status"] == "not_charging"
 
     @pytest.mark.asyncio
-    async def test_turn_on_reverts_on_failure(self, charge_switch):
+    async def test_turn_on_no_update_on_failure(self, charge_switch):
         charge_switch.coordinator.async_send_command_and_wait.return_value = False
         await charge_switch.async_turn_on()
-        assert charge_switch.coordinator.async_set_updated_data.call_count == 2
+        charge_switch.coordinator.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_no_update_on_failure(self, charge_switch):
+        charge_switch.coordinator.async_send_command_and_wait.return_value = False
+        await charge_switch.async_turn_off()
+        charge_switch.coordinator.async_set_updated_data.assert_not_called()
 
 
 class TestDefrostSwitch:


### PR DESCRIPTION
## Summary

- Improved error handling and timeout logging with differentiated timeout vs generic failure messages
- Updated dependency to `pymyhondaplus` 5.2.2
- Removed optimistic state updates from command entities (switch, number, select) — entity state now only changes after the car confirms success
- Lock entity retains native `is_locking`/`is_unlocking` pending indicators
- Added persistent notifications for timeout failures (dashboard refresh, commands, location refresh), including the vehicle name
- Non-timeout failures surface through logs and service errors only, not persistent notifications

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests pass (`python -m pytest tests/ -q`)
- [x] Lint passes (`ruff check .`)
- [x] Tested on Home Assistant

## Vehicle tested

<!-- Which Honda vehicle model was this tested on? -->