### PR TITLE
Scope timeout notifications to manual actions

### DIFF
--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -175,7 +175,9 @@ def _schedule_car_refresh(
         async def _refresh():
             if entry.runtime_data.car_refresh_enabled:
                 try:
-                    await coordinator.async_refresh_from_car()
+                    await coordinator.async_refresh_from_car(
+                        notify_on_timeout=False,
+                    )
                     LOGGER.debug("Scheduled refresh from car completed")
                 except Exception:
                     LOGGER.warning("Scheduled refresh from car failed", exc_info=True)
@@ -207,7 +209,9 @@ def _schedule_location_refresh(
         """Refresh location and reschedule."""
         async def _refresh():
             try:
-                await coordinator.async_refresh_location()
+                await coordinator.async_refresh_location(
+                    notify_on_timeout=False,
+                )
                 LOGGER.debug("Scheduled location refresh completed")
             except Exception:
                 LOGGER.warning("Scheduled location refresh failed", exc_info=True)

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -136,7 +136,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         """Request fresh data from the car and return the command result."""
         return self.api.refresh_dashboard(self.vin)
 
-    async def async_refresh_from_car(self) -> None:
+    async def async_refresh_from_car(self, *, notify_on_timeout: bool = True) -> None:
         """Request fresh data from the car (wakes TCU, polls until done)."""
         try:
             result = await self.hass.async_add_executor_job(self._refresh_from_car)
@@ -147,12 +147,13 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                         result.status,
                         result.reason,
                     )
-                    pn_async_create(
-                        self.hass,
-                        f"Dashboard refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
-                        title="My Honda+",
-                        notification_id=f"{DOMAIN}_refresh_timeout",
-                    )
+                    if notify_on_timeout:
+                        pn_async_create(
+                            self.hass,
+                            f"Dashboard refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                            title="My Honda+",
+                            notification_id=f"{DOMAIN}_refresh_timeout",
+                        )
                 else:
                     LOGGER.warning(
                         "Dashboard refresh did not succeed (status=%s, reason=%s)",
@@ -184,7 +185,9 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         self._persist_tokens_if_changed()
         return result
 
-    async def async_send_command_and_wait(self, func, *args, timeout: int = 90) -> bool:
+    async def async_send_command_and_wait(
+        self, func, *args, timeout: int = 90, notify_on_timeout: bool = True,
+    ) -> bool:
         """Send a command and wait for confirmation. Raises on send failure."""
         command_id = await self.async_send_command(func, *args)
         if not command_id:
@@ -200,12 +203,13 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                     result.status,
                     result.reason,
                 )
-                pn_async_create(
-                    self.hass,
-                    f"A command for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
-                    title="My Honda+",
-                    notification_id=f"{DOMAIN}_command_timeout",
-                )
+                if notify_on_timeout:
+                    pn_async_create(
+                        self.hass,
+                        f"A command for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                        title="My Honda+",
+                        notification_id=f"{DOMAIN}_command_timeout",
+                    )
             else:
                 LOGGER.warning(
                     "Command did not succeed (id=%s, status=%s, reason=%s)",
@@ -215,7 +219,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                 )
         return result.success
 
-    async def async_refresh_location(self) -> None:
+    async def async_refresh_location(self, *, notify_on_timeout: bool = True) -> None:
         """Request fresh GPS location from the car and update dashboard."""
         try:
             command_id = await self.async_send_command(
@@ -232,12 +236,13 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
                         result.status,
                         result.reason,
                     )
-                    pn_async_create(
-                        self.hass,
-                        f"Location refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
-                        title="My Honda+",
-                        notification_id=f"{DOMAIN}_location_timeout",
-                    )
+                    if notify_on_timeout:
+                        pn_async_create(
+                            self.hass,
+                            f"Location refresh for {self._vehicle_name or self.vin} timed out waiting for the car to respond.",
+                            title="My Honda+",
+                            notification_id=f"{DOMAIN}_location_timeout",
+                        )
                 else:
                     LOGGER.warning(
                         "Location refresh command did not succeed (id=%s, status=%s, reason=%s)",

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.2.2"],
-  "version": "4.4.0"
+  "version": "4.4.1-beta.1"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -323,6 +323,19 @@ class TestHondaDataUpdateCoordinator:
             notification_id="myhondaplus_location_timeout",
         )
 
+    @pytest.mark.asyncio
+    async def test_refresh_location_timeout_without_notification(self, coordinator):
+        coordinator.async_send_command = AsyncMock(return_value="cmd-123")
+        coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
+            success=False, status="timeout", timed_out=True, reason=None,
+        )
+
+        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            with pytest.raises(HomeAssistantError, match="Unable to refresh location"):
+                await coordinator.async_refresh_location(notify_on_timeout=False)
+
+        pn_create.assert_not_called()
+
 
 class TestHondaTripCoordinator:
     @pytest.mark.asyncio

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -457,6 +457,25 @@ class TestCoordinatorCoverage:
         logger.warning.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_send_command_and_wait_timeout_without_notification(self):
+        coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
+        coord.async_send_command = AsyncMock(return_value="cmd")
+        coord.hass = MagicMock()
+        coord.api = MagicMock()
+        coord._vehicle_name = MOCK_VEHICLE_NAME
+        coord.hass.async_add_executor_job = AsyncMock(
+            return_value=SimpleNamespace(
+                success=False, status="timeout", timed_out=True, reason=None,
+            ),
+        )
+        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            result = await HondaDataUpdateCoordinator.async_send_command_and_wait(
+                coord, MagicMock(), notify_on_timeout=False,
+            )
+        assert result is False
+        pn_create.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_refresh_location_api_failure_raises(self):
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.vin = MOCK_VIN


### PR DESCRIPTION
## Summary
- limit timeout persistent notifications to explicit user-triggered actions
- suppress persistent notifications for scheduled car and location refresh loops
- add regression coverage for the notification gating
- bump the integration version to 4.4.1-beta.1

## Verification
- ruff check custom_components/myhondaplus tests pyproject.toml
- pytest tests/ -q --cov=custom_components/myhondaplus --cov-report=term-missing --cov-fail-under=95
  - 269 passed
  - 95.08% coverage