### PR TITLE
Multi-vehicle per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,21 @@ The integration will ask for:
 
 These refresh settings are stored as integration options and can be changed later from **Settings > Integrations > My Honda+ > Configure**.
 
-Vehicles on your account are auto-detected. If you have multiple vehicles, you'll be asked to pick one. The vehicle's Honda+ nickname is used as the device name in Home Assistant.
+All vehicles on your account are auto-detected and set up as separate devices under a single integration entry. Each vehicle's Honda+ nickname is used as its device name in Home Assistant.
 
 On first setup, Honda will send a verification email. Copy the link URL (don't click it) and paste it in the verification step.
 
 Installation parameters summary:
 - **Integration source**: HACS or manual installation
 - **Verification link**: Required only when Honda asks to register the device authenticator
-- **Vehicle selection**: Required only when multiple vehicles are found on the account
 
 ## Translations
 
 The integration is fully translated in all Honda Connect Europe languages: Czech, Danish, Dutch, English, French, German, Hungarian, Italian, Norwegian, Polish, Slovak, Spanish, and Swedish.
 
 ## Entities
+
+Entities are filtered based on the vehicle's capabilities — only features the vehicle actually supports are created (e.g., no EV charging entities on petrol cars, no climate controls if remote climate is not available). Honda's UI configuration hints are also respected (e.g., hiding window status or interior temperature where applicable).
 
 Units are dynamic — the integration uses whatever the vehicle reports (km/miles, °C/°F).
 
@@ -204,7 +205,7 @@ GPS updates depend on the "Refresh from car" interval and the "Location refresh 
 <details>
 <summary><strong>Multiple vehicles</strong></summary>
 
-Each vehicle requires its own integration entry. Go to **Settings > Integrations > Add Integration > My Honda+** and add the same account again — you'll be prompted to select a different vehicle.
+All vehicles on your account are automatically detected and added as separate devices under a single integration entry. If you add a new vehicle to your Honda+ account, remove and re-add the integration to pick it up.
 </details>
 
 ## Related projects

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_CAR_REFRESH_INTERVAL,
     CONF_FUEL_TYPE,
     CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_MODEL,
     CONF_PERSONAL_ID,
     CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
@@ -257,6 +258,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
         user_id=entry.data.get(CONF_USER_ID, ""),
     )
 
+    # Backfill model names for upgrades from versions without model data
+    await _backfill_models(hass, entry, api)
+
     vehicles: dict[str, VehicleData] = {}
     for v in entry.data.get(CONF_VEHICLES, []):
         vin = v[CONF_VIN]
@@ -302,7 +306,56 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
         _schedule_location_refresh(hass, entry, vd)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Set model on devices from stored vehicle data
+    _update_device_models(hass, entry)
+
     return True
+
+
+async def _backfill_models(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    api: HondaAPI,
+) -> None:
+    """Fetch model names for vehicles that don't have them (upgrade path)."""
+    vehicle_list = entry.data.get(CONF_VEHICLES, [])
+    if all(v.get(CONF_MODEL) for v in vehicle_list):
+        return
+
+    try:
+        from .config_flow import _parse_vehicles
+
+        user_info = await hass.async_add_executor_job(api.get_user_info)
+        api_vehicles = {v["vin"]: v for v in _parse_vehicles(user_info)}
+        updated = []
+        for v in vehicle_list:
+            vin = v[CONF_VIN]
+            api_v = api_vehicles.get(vin, {})
+            updated.append({**v, CONF_MODEL: api_v.get("model", v.get(CONF_MODEL, ""))})
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_VEHICLES: updated},
+        )
+    except Exception:
+        LOGGER.debug("Could not backfill model names", exc_info=True)
+
+
+def _update_device_models(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+) -> None:
+    """Set the model field on devices from stored vehicle data."""
+    device_registry = dr.async_get(hass)
+    for v in entry.data.get(CONF_VEHICLES, []):
+        model = v.get(CONF_MODEL, "")
+        if not model:
+            continue
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, v[CONF_VIN])},
+        )
+        if device and device.model != model:
+            device_registry.async_update_device(device.id, model=model)
 
 
 def _schedule_car_refresh(

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import selector
 from homeassistant.helpers.event import async_call_later
-from pymyhondaplus.api import HondaAPI
+from pymyhondaplus.api import HondaAPI, Vehicle
 
 from .const import (
     CONF_ACCESS_TOKEN,
@@ -258,8 +258,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
         user_id=entry.data.get(CONF_USER_ID, ""),
     )
 
-    # Backfill model names for upgrades from versions without model data
-    await _backfill_models(hass, entry, api)
+    # Fetch vehicle metadata (capabilities, UI config, backfill models)
+    api_vehicles = await _fetch_vehicle_metadata(hass, entry, api)
 
     vehicles: dict[str, VehicleData] = {}
     for v in entry.data.get(CONF_VEHICLES, []):
@@ -287,12 +287,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
         )
         await trip_coordinator.async_config_entry_first_refresh()
 
+        api_vehicle = api_vehicles.get(vin)
         vehicles[vin] = VehicleData(
             coordinator=coordinator,
             trip_coordinator=trip_coordinator,
             vin=vin,
             vehicle_name=vehicle_name,
             fuel_type=fuel_type,
+            **(
+                {
+                    "capabilities": api_vehicle.capabilities,
+                    "ui_config": api_vehicle.ui_config,
+                }
+                if api_vehicle
+                else {}
+            ),
         )
 
     entry.runtime_data = MyHondaPlusData(vehicles=vehicles, api=api)
@@ -313,32 +322,62 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) 
     return True
 
 
-async def _backfill_models(
+async def _fetch_vehicle_metadata(
     hass: HomeAssistant,
     entry: MyHondaPlusConfigEntry,
     api: HondaAPI,
-) -> None:
-    """Fetch model names for vehicles that don't have them (upgrade path)."""
-    vehicle_list = entry.data.get(CONF_VEHICLES, [])
-    if all(v.get(CONF_MODEL) for v in vehicle_list):
-        return
+) -> dict[str, Vehicle]:
+    """Fetch Vehicle objects from the API.
 
+    Also backfills model names for vehicles that don't have them (upgrade path).
+    Returns a dict of VIN → Vehicle for capability/UI config extraction.
+    """
     try:
-        from .config_flow import _parse_vehicles
+        api_vehicles = await hass.async_add_executor_job(api.get_vehicles)
+    except Exception:
+        LOGGER.debug("Could not fetch vehicle metadata", exc_info=True)
+        return {}
 
-        user_info = await hass.async_add_executor_job(api.get_user_info)
-        api_vehicles = {v["vin"]: v for v in _parse_vehicles(user_info)}
+    vehicles_by_vin = {v.vin: v for v in api_vehicles}
+
+    # Backfill model names if missing
+    vehicle_list = entry.data.get(CONF_VEHICLES, [])
+    if not all(v.get(CONF_MODEL) for v in vehicle_list):
         updated = []
         for v in vehicle_list:
             vin = v[CONF_VIN]
-            api_v = api_vehicles.get(vin, {})
-            updated.append({**v, CONF_MODEL: api_v.get("model", v.get(CONF_MODEL, ""))})
+            api_v = vehicles_by_vin.get(vin)
+            if api_v and not v.get(CONF_MODEL):
+                model = _build_model_name_from_vehicle(api_v)
+                updated.append({**v, CONF_MODEL: model})
+            else:
+                updated.append(v)
         hass.config_entries.async_update_entry(
             entry,
             data={**entry.data, CONF_VEHICLES: updated},
         )
-    except Exception:
-        LOGGER.debug("Could not backfill model names", exc_info=True)
+
+    return vehicles_by_vin
+
+
+def _build_model_name_from_vehicle(vehicle: Vehicle) -> str:
+    """Build a display model name from a Vehicle dataclass."""
+    friendly = vehicle.model_name
+    grade = vehicle.grade
+    year = vehicle.model_year
+
+    if friendly and grade:
+        parts = grade.split(None, 1)
+        grade = (
+            parts[1].title() if len(parts) > 1 and len(parts[0]) <= 2 else grade.title()
+        )
+
+    name = friendly
+    if grade:
+        name = f"{name} {grade}" if name else grade
+    if year:
+        name = f"{name} ({year})" if name else str(year)
+    return name
 
 
 def _update_device_models(

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -1,6 +1,7 @@
 """My Honda+ integration for Home Assistant."""
 
 import re
+from dataclasses import replace
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
@@ -561,9 +562,9 @@ def _register_services(hass: HomeAssistant) -> None:
             if isinstance(days, str):
                 rule["days"] = [d.strip() for d in days.split(",") if d.strip()]
             enriched.append(rule)
-        data = dict(coordinator.data)
-        data[key] = enriched
-        coordinator.async_set_updated_data(data)
+        coordinator.async_set_updated_data(
+            replace(coordinator.data, **{key: enriched})
+        )
 
         @callback
         def _refresh(_now):
@@ -608,12 +609,15 @@ def _register_services(hass: HomeAssistant) -> None:
             coordinator.vin,
         )
         if confirmed:
-            new_data = dict(coordinator.data)
-            new_data["climate_active"] = True
-            new_data["climate_temp"] = temp
-            new_data["climate_duration"] = duration
-            new_data["climate_defrost"] = defrost
-            coordinator.async_set_updated_data(new_data)
+            coordinator.async_set_updated_data(
+                replace(
+                    coordinator.data,
+                    climate_active=True,
+                    climate_temp=temp,
+                    climate_duration=duration,
+                    climate_defrost=defrost,
+                )
+            )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -4,31 +4,50 @@ import re
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import CONF_EMAIL, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import selector
 from homeassistant.helpers.event import async_call_later
+from pymyhondaplus.api import HondaAPI
 
 from .const import (
+    CONF_ACCESS_TOKEN,
     CONF_CAR_REFRESH_INTERVAL,
+    CONF_FUEL_TYPE,
     CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_PERSONAL_ID,
+    CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
+    CONF_USER_ID,
+    CONF_VEHICLE_NAME,
+    CONF_VEHICLES,
+    CONF_VIN,
     DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_LOCATION_REFRESH_INTERVAL,
     DOMAIN,
     LOGGER,
 )
 from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
-from .data import MyHondaPlusConfigEntry, MyHondaPlusData
+from .data import MyHondaPlusConfigEntry, MyHondaPlusData, VehicleData
 from .entry_options import get_entry_value
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.LOCK, Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.DEVICE_TRACKER,
+    Platform.LOCK,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 SERVICE_SET_CHARGE_SCHEDULE = "set_charge_schedule"
 SERVICE_SET_CLIMATE_SCHEDULE = "set_climate_schedule"
 SERVICE_CLIMATE_ON = "climate_on"
-ATTR_CONFIG_ENTRY = "config_entry"
+ATTR_DEVICE = "device"
 
 
 VALID_DAYS = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
@@ -58,22 +77,26 @@ def _validate_time(value: str) -> str:
     return value
 
 
-CHARGE_RULE_SCHEMA = vol.Schema({
-    vol.Required("days"): _validate_days,
-    vol.Required("location"): vol.In(["home", "all"]),
-    vol.Required("start_time"): _validate_time,
-    vol.Required("end_time"): _validate_time,
-    vol.Optional("enabled", default=True): bool,
-})
+CHARGE_RULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("days"): _validate_days,
+        vol.Required("location"): vol.In(["home", "all"]),
+        vol.Required("start_time"): _validate_time,
+        vol.Required("end_time"): _validate_time,
+        vol.Optional("enabled", default=True): bool,
+    }
+)
 
-CLIMATE_RULE_SCHEMA = vol.Schema({
-    vol.Required("days"): _validate_days,
-    vol.Required("start_time"): _validate_time,
-    vol.Optional("enabled", default=True): bool,
-})
+CLIMATE_RULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("days"): _validate_days,
+        vol.Required("start_time"): _validate_time,
+        vol.Optional("enabled", default=True): bool,
+    }
+)
 
 BASE_SERVICE_FIELDS = {
-    vol.Required(ATTR_CONFIG_ENTRY): selector.ConfigEntrySelector(
+    vol.Required(ATTR_DEVICE): selector.DeviceSelector(
         {
             "integration": DOMAIN,
         }
@@ -82,7 +105,9 @@ BASE_SERVICE_FIELDS = {
 SERVICE_CLIMATE_ON_FIELDS = {
     **BASE_SERVICE_FIELDS,
     vol.Optional("temp", default="normal"): vol.In(["cooler", "normal", "hotter"]),
-    vol.Optional("duration", default=30): vol.All(vol.Coerce(int), vol.In([10, 20, 30])),
+    vol.Optional("duration", default=30): vol.All(
+        vol.Coerce(int), vol.In([10, 20, 30])
+    ),
     vol.Optional("defrost", default=True): bool,
 }
 SERVICE_CHARGE_SCHEDULE_FIELDS = {
@@ -105,7 +130,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: MyHondaPlusConfigEntry
+) -> bool:
     """Migrate old config entries to the latest version."""
     if entry.version == 1:
         option_keys = (
@@ -129,128 +156,298 @@ async def async_migrate_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry
             version=2,
         )
 
+    if entry.version == 2:
+        new_data = dict(entry.data)
+        vehicles = [
+            {
+                CONF_VIN: new_data.pop(CONF_VIN),
+                CONF_VEHICLE_NAME: new_data.pop(CONF_VEHICLE_NAME, ""),
+                CONF_FUEL_TYPE: new_data.pop(CONF_FUEL_TYPE, ""),
+            }
+        ]
+        new_data[CONF_VEHICLES] = vehicles
+
+        email = new_data.get(CONF_EMAIL, "")
+        hass.config_entries.async_update_entry(
+            entry,
+            data=new_data,
+            unique_id=email.lower() if email else entry.unique_id,
+            version=3,
+        )
+
     return True
+
+
+def _consolidate_duplicate_entries(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+) -> None:
+    """Merge duplicate v3 entries for the same email into this entry.
+
+    Phase 2 of migration: runs at the start of async_setup_entry.
+    """
+    email = entry.data.get(CONF_EMAIL, "").lower()
+    if not email:
+        return
+
+    duplicates = []
+    for other in hass.config_entries.async_entries(DOMAIN):
+        if other.entry_id == entry.entry_id:
+            continue
+        if other.data.get(CONF_EMAIL, "").lower() == email:
+            duplicates.append(other)
+
+    if not duplicates:
+        return
+
+    # Merge vehicles from duplicates into this entry
+    existing_vins = {v[CONF_VIN] for v in entry.data.get(CONF_VEHICLES, [])}
+    merged_vehicles = list(entry.data.get(CONF_VEHICLES, []))
+
+    for dup in duplicates:
+        for v in dup.data.get(CONF_VEHICLES, []):
+            if v[CONF_VIN] not in existing_vins:
+                merged_vehicles.append(v)
+                existing_vins.add(v[CONF_VIN])
+
+    new_data = {**entry.data, CONF_VEHICLES: merged_vehicles}
+    hass.config_entries.async_update_entry(entry, data=new_data)
+
+    for dup in duplicates:
+        LOGGER.info(
+            "Removing duplicate config entry %s (merged into %s)",
+            dup.entry_id,
+            entry.entry_id,
+        )
+        hass.async_create_task(hass.config_entries.async_remove(dup.entry_id))
+
+
+def _cleanup_removed_vehicles(
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    active_vins: set[str],
+) -> None:
+    """Remove devices/entities for vehicles no longer in the vehicle list."""
+    device_registry = dr.async_get(hass)
+    devices_to_remove = []
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        for domain, identifier in device.identifiers:
+            if domain == DOMAIN and identifier not in active_vins:
+                devices_to_remove.append(device.id)
+                break
+
+    for device_id in devices_to_remove:
+        LOGGER.info("Removing device for vehicle no longer in account: %s", device_id)
+        device_registry.async_remove_device(device_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
     """Set up My Honda+ from a config entry."""
+    # Phase 2: consolidate duplicate entries from migration
+    _consolidate_duplicate_entries(hass, entry)
+
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
-    coordinator = HondaDataUpdateCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
-
-    trip_coordinator = HondaTripCoordinator(
-        hass, entry, coordinator.api, coordinator._persist_tokens_if_changed,
-        main_coordinator=coordinator,
-    )
-    await trip_coordinator.async_config_entry_first_refresh()
-
-    entry.runtime_data = MyHondaPlusData(
-        coordinator=coordinator,
-        trip_coordinator=trip_coordinator,
+    # Create one shared API instance
+    api = HondaAPI()
+    api.set_tokens(
+        access_token=entry.data[CONF_ACCESS_TOKEN],
+        refresh_token=entry.data[CONF_REFRESH_TOKEN],
+        personal_id=entry.data.get(CONF_PERSONAL_ID, ""),
+        user_id=entry.data.get(CONF_USER_ID, ""),
     )
 
-    _schedule_car_refresh(hass, entry)
-    _schedule_location_refresh(hass, entry)
+    vehicles: dict[str, VehicleData] = {}
+    for v in entry.data.get(CONF_VEHICLES, []):
+        vin = v[CONF_VIN]
+        vehicle_name = v.get(CONF_VEHICLE_NAME, "")
+        fuel_type = v.get(CONF_FUEL_TYPE, "")
+
+        coordinator = HondaDataUpdateCoordinator(
+            hass,
+            entry,
+            api,
+            vin,
+            vehicle_name,
+        )
+        await coordinator.async_config_entry_first_refresh()
+
+        trip_coordinator = HondaTripCoordinator(
+            hass,
+            entry,
+            api,
+            coordinator._persist_tokens_if_changed,
+            vin=vin,
+            fuel_type=fuel_type,
+            main_coordinator=coordinator,
+        )
+        await trip_coordinator.async_config_entry_first_refresh()
+
+        vehicles[vin] = VehicleData(
+            coordinator=coordinator,
+            trip_coordinator=trip_coordinator,
+            vin=vin,
+            vehicle_name=vehicle_name,
+            fuel_type=fuel_type,
+        )
+
+    entry.runtime_data = MyHondaPlusData(vehicles=vehicles, api=api)
+
+    # Clean up devices for removed vehicles
+    _cleanup_removed_vehicles(hass, entry, set(vehicles.keys()))
+
+    # Schedule per-vehicle refreshes
+    for vd in vehicles.values():
+        _schedule_car_refresh(hass, entry, vd)
+        _schedule_location_refresh(hass, entry, vd)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 def _schedule_car_refresh(
-    hass: HomeAssistant, entry: MyHondaPlusConfigEntry,
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    vd: VehicleData,
 ) -> None:
     """Schedule a recurring refresh-from-car if configured."""
     interval = get_entry_value(
-        entry, CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL,
+        entry,
+        CONF_CAR_REFRESH_INTERVAL,
+        DEFAULT_CAR_REFRESH_INTERVAL,
     )
     if not interval or interval <= 0:
         return
 
-    coordinator = entry.runtime_data.coordinator
+    coordinator = vd.coordinator
 
     @callback
     def _do_car_refresh(_now) -> None:
         """Refresh from car and reschedule."""
+
         async def _refresh():
-            if entry.runtime_data.car_refresh_enabled:
+            if vd.car_refresh_enabled:
                 try:
                     await coordinator.async_refresh_from_car(
                         notify_on_timeout=False,
                     )
-                    LOGGER.debug("Scheduled refresh from car completed")
+                    LOGGER.debug("Scheduled refresh from car completed for %s", vd.vin)
                 except Exception:
-                    LOGGER.warning("Scheduled refresh from car failed", exc_info=True)
-            entry.runtime_data.car_refresh_unsub = async_call_later(
-                hass, interval, _do_car_refresh,
+                    LOGGER.warning(
+                        "Scheduled refresh from car failed for %s",
+                        vd.vin,
+                        exc_info=True,
+                    )
+            vd.car_refresh_unsub = async_call_later(
+                hass,
+                interval,
+                _do_car_refresh,
             )
 
         hass.async_create_task(_refresh())
 
-    entry.runtime_data.car_refresh_unsub = async_call_later(
-        hass, interval, _do_car_refresh,
+    vd.car_refresh_unsub = async_call_later(
+        hass,
+        interval,
+        _do_car_refresh,
     )
 
 
 def _schedule_location_refresh(
-    hass: HomeAssistant, entry: MyHondaPlusConfigEntry,
+    hass: HomeAssistant,
+    entry: MyHondaPlusConfigEntry,
+    vd: VehicleData,
 ) -> None:
     """Schedule a recurring location refresh if configured."""
     interval = get_entry_value(
-        entry, CONF_LOCATION_REFRESH_INTERVAL, DEFAULT_LOCATION_REFRESH_INTERVAL,
+        entry,
+        CONF_LOCATION_REFRESH_INTERVAL,
+        DEFAULT_LOCATION_REFRESH_INTERVAL,
     )
     if not interval or interval <= 0:
         return
 
-    coordinator = entry.runtime_data.coordinator
+    coordinator = vd.coordinator
 
     @callback
     def _do_location_refresh(_now) -> None:
         """Refresh location and reschedule."""
+
         async def _refresh():
             try:
                 await coordinator.async_refresh_location(
                     notify_on_timeout=False,
                 )
-                LOGGER.debug("Scheduled location refresh completed")
+                LOGGER.debug("Scheduled location refresh completed for %s", vd.vin)
             except Exception:
-                LOGGER.warning("Scheduled location refresh failed", exc_info=True)
-            entry.runtime_data.location_refresh_unsub = async_call_later(
-                hass, interval, _do_location_refresh,
+                LOGGER.warning(
+                    "Scheduled location refresh failed for %s", vd.vin, exc_info=True
+                )
+            vd.location_refresh_unsub = async_call_later(
+                hass,
+                interval,
+                _do_location_refresh,
             )
 
         hass.async_create_task(_refresh())
 
-    entry.runtime_data.location_refresh_unsub = async_call_later(
-        hass, interval, _do_location_refresh,
+    vd.location_refresh_unsub = async_call_later(
+        hass,
+        interval,
+        _do_location_refresh,
     )
 
 
 def _get_coordinator(
-    hass: HomeAssistant, call: ServiceCall,
+    hass: HomeAssistant,
+    call: ServiceCall,
 ) -> HondaDataUpdateCoordinator:
-    """Resolve the coordinator for a service call config entry."""
-    entry_id = call.data[ATTR_CONFIG_ENTRY]
-    entry = hass.config_entries.async_get_entry(entry_id)
-    if entry is None or entry.domain != DOMAIN:
+    """Resolve the coordinator for a service call via device selector."""
+    device_id = call.data.get(ATTR_DEVICE)
+    if not device_id:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="config_entry_not_found",
-            translation_placeholders={"service": call.service, "entry_id": entry_id},
+            translation_key="device_required",
         )
-    if entry.state != ConfigEntryState.LOADED:
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+    if device is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="config_entry_not_loaded",
-            translation_placeholders={"service": call.service, "entry_id": entry_id},
+            translation_key="device_not_found",
         )
-    if not hasattr(entry, "runtime_data") or not entry.runtime_data:
+
+    # Extract VIN from device identifiers: {(DOMAIN, vin)}
+    vin = None
+    for domain, identifier in device.identifiers:
+        if domain == DOMAIN:
+            vin = identifier
+            break
+    if vin is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="config_entry_no_data",
-            translation_placeholders={"service": call.service, "entry_id": entry_id},
+            translation_key="device_not_found",
         )
-    return entry.runtime_data.coordinator
+
+    # Find the config entry that owns this vehicle
+    for entry_id in device.config_entries:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if (
+            entry
+            and entry.domain == DOMAIN
+            and entry.state == ConfigEntryState.LOADED
+            and hasattr(entry, "runtime_data")
+            and entry.runtime_data
+        ):
+            vehicle = entry.runtime_data.vehicles.get(vin)
+            if vehicle:
+                return vehicle.coordinator
+
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="device_not_found",
+    )
 
 
 def _register_services(hass: HomeAssistant) -> None:
@@ -286,7 +483,9 @@ def _register_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator(hass, call)
         rules = call.data["rules"]
         await coordinator.async_send_command(
-            coordinator.api.set_charge_schedule, coordinator.vin, rules,
+            coordinator.api.set_charge_schedule,
+            coordinator.vin,
+            rules,
         )
         _optimistic_schedule_update(coordinator, "charge_schedule", rules)
 
@@ -294,7 +493,9 @@ def _register_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator(hass, call)
         rules = call.data["rules"]
         await coordinator.async_send_command(
-            coordinator.api.set_climate_schedule, coordinator.vin, rules,
+            coordinator.api.set_climate_schedule,
+            coordinator.vin,
+            rules,
         )
         _optimistic_schedule_update(coordinator, "climate_schedule", rules)
 
@@ -305,10 +506,14 @@ def _register_services(hass: HomeAssistant) -> None:
         defrost = call.data.get("defrost", True)
         await coordinator.async_send_command_and_wait(
             coordinator.api.set_climate_settings,
-            coordinator.vin, temp, duration, defrost,
+            coordinator.vin,
+            temp,
+            duration,
+            defrost,
         )
         confirmed = await coordinator.async_send_command_and_wait(
-            coordinator.api.remote_climate_start, coordinator.vin,
+            coordinator.api.remote_climate_start,
+            coordinator.vin,
         )
         if confirmed:
             new_data = dict(coordinator.data)
@@ -319,30 +524,41 @@ def _register_services(hass: HomeAssistant) -> None:
             coordinator.async_set_updated_data(new_data)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SET_CHARGE_SCHEDULE,
-        handle_set_charge_schedule, schema=SERVICE_CHARGE_SCHEDULE_SCHEMA,
+        DOMAIN,
+        SERVICE_SET_CHARGE_SCHEDULE,
+        handle_set_charge_schedule,
+        schema=SERVICE_CHARGE_SCHEDULE_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_SET_CLIMATE_SCHEDULE,
-        handle_set_climate_schedule, schema=SERVICE_CLIMATE_SCHEDULE_SCHEMA,
+        DOMAIN,
+        SERVICE_SET_CLIMATE_SCHEDULE,
+        handle_set_climate_schedule,
+        schema=SERVICE_CLIMATE_SCHEDULE_SCHEMA,
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_CLIMATE_ON,
-        handle_climate_on, schema=SERVICE_CLIMATE_ON_SCHEMA,
+        DOMAIN,
+        SERVICE_CLIMATE_ON,
+        handle_climate_on,
+        schema=SERVICE_CLIMATE_ON_SCHEMA,
     )
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: MyHondaPlusConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if entry.runtime_data.car_refresh_unsub:
-        entry.runtime_data.car_refresh_unsub()
-        entry.runtime_data.car_refresh_unsub = None
-    if entry.runtime_data.location_refresh_unsub:
-        entry.runtime_data.location_refresh_unsub()
-        entry.runtime_data.location_refresh_unsub = None
+    for vd in entry.runtime_data.vehicles.values():
+        if vd.car_refresh_unsub:
+            vd.car_refresh_unsub()
+            vd.car_refresh_unsub = None
+        if vd.location_refresh_unsub:
+            vd.location_refresh_unsub()
+            vd.location_refresh_unsub = None
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: MyHondaPlusConfigEntry) -> None:
+async def async_reload_entry(
+    hass: HomeAssistant, entry: MyHondaPlusConfigEntry
+) -> None:
     """Reload config entry."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/myhondaplus/binary_sensor.py
+++ b/custom_components/myhondaplus/binary_sensor.py
@@ -95,7 +95,7 @@ class HondaBinarySensor(MyHondaPlusEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
-        value = self.coordinator.data.get(self.entity_description.data_key)
+        value = getattr(self.coordinator.data, self.entity_description.data_key, None)
         result = to_bool(value)
         if result is None:
             return None

--- a/custom_components/myhondaplus/binary_sensor.py
+++ b/custom_components/myhondaplus/binary_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity, to_bool
 
@@ -70,13 +69,19 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ binary sensors."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities(
-        HondaBinarySensor(coordinator, description, vin, vehicle_name)
-        for description in BINARY_SENSOR_DESCRIPTIONS
-    )
+    entities = []
+    for vehicle in entry.runtime_data.vehicles.values():
+        entities.extend(
+            HondaBinarySensor(
+                vehicle.coordinator,
+                desc,
+                vehicle.vin,
+                vehicle.vehicle_name,
+                vehicle.fuel_type,
+            )
+            for desc in BINARY_SENSOR_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class HondaBinarySensor(MyHondaPlusEntity, BinarySensorEntity):

--- a/custom_components/myhondaplus/binary_sensor.py
+++ b/custom_components/myhondaplus/binary_sensor.py
@@ -20,6 +20,7 @@ PARALLEL_UPDATES = 0
 class HondaBinarySensorDescription(BinarySensorEntityDescription):
     data_key: str = ""
     invert: bool = False
+    ui_hide: str = ""
 
 
 BINARY_SENSOR_DESCRIPTIONS: list[HondaBinarySensorDescription] = [
@@ -38,6 +39,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[HondaBinarySensorDescription] = [
         icon="mdi:car-door",
         data_key="all_windows_closed",
         invert=True,
+        ui_hide="hide_window_status",
     ),
     HondaBinarySensorDescription(
         key="hood",
@@ -80,6 +82,8 @@ async def async_setup_entry(
                 vehicle.fuel_type,
             )
             for desc in BINARY_SENSOR_DESCRIPTIONS
+            if not desc.ui_hide
+            or not getattr(vehicle.ui_config, desc.ui_hide, False)
         )
     async_add_entities(entities)
 

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -6,7 +6,6 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity
 
@@ -46,13 +45,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ buttons."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities(
-        HondaButton(coordinator, description, vin, vehicle_name)
-        for description in BUTTON_DESCRIPTIONS
-    )
+    entities = []
+    for v in entry.runtime_data.vehicles.values():
+        entities.extend(
+            HondaButton(v.coordinator, desc, v.vin, v.vehicle_name, v.fuel_type)
+            for desc in BUTTON_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class HondaButton(MyHondaPlusEntity, ButtonEntity):
@@ -64,7 +63,9 @@ class HondaButton(MyHondaPlusEntity, ButtonEntity):
         vin = self._vin
 
         if action == "horn_lights":
-            await self.coordinator.async_send_command_and_wait(api.remote_horn_lights, vin)
+            await self.coordinator.async_send_command_and_wait(
+                api.remote_horn_lights, vin
+            )
         elif action == "refresh_cached":
             await self.coordinator.async_request_refresh()
         elif action == "refresh":

--- a/custom_components/myhondaplus/button.py
+++ b/custom_components/myhondaplus/button.py
@@ -15,6 +15,7 @@ PARALLEL_UPDATES = 1
 @dataclass(frozen=True, kw_only=True)
 class HondaButtonDescription(ButtonEntityDescription):
     action: str = ""
+    capability: str = ""
 
 
 BUTTON_DESCRIPTIONS: list[HondaButtonDescription] = [
@@ -23,6 +24,7 @@ BUTTON_DESCRIPTIONS: list[HondaButtonDescription] = [
         translation_key="horn_lights",
         icon="mdi:bullhorn",
         action="horn_lights",
+        capability="remote_horn",
     ),
     HondaButtonDescription(
         key="refresh_cached",
@@ -50,6 +52,8 @@ async def async_setup_entry(
         entities.extend(
             HondaButton(v.coordinator, desc, v.vin, v.vehicle_name, v.fuel_type)
             for desc in BUTTON_DESCRIPTIONS
+            if not desc.capability
+            or getattr(v.capabilities, desc.capability, True)
         )
     async_add_entities(entities)
 

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_REFRESH_TOKEN,
     CONF_USER_ID,
     CONF_VEHICLE_NAME,
+    CONF_VEHICLES,
     CONF_VIN,
     DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_LOCATION_REFRESH_INTERVAL,
@@ -25,22 +26,32 @@ from .const import (
 )
 from .entry_options import get_entry_value
 
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_EMAIL): str,
-    vol.Required(CONF_PASSWORD): str,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
-    vol.Optional(CONF_CAR_REFRESH_INTERVAL, default=DEFAULT_CAR_REFRESH_INTERVAL): int,
-    vol.Optional(CONF_LOCATION_REFRESH_INTERVAL, default=DEFAULT_LOCATION_REFRESH_INTERVAL): int,
-})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
+        vol.Optional(
+            CONF_CAR_REFRESH_INTERVAL, default=DEFAULT_CAR_REFRESH_INTERVAL
+        ): int,
+        vol.Optional(
+            CONF_LOCATION_REFRESH_INTERVAL, default=DEFAULT_LOCATION_REFRESH_INTERVAL
+        ): int,
+    }
+)
 
-STEP_VERIFY_DATA_SCHEMA = vol.Schema({
-    vol.Required("verification_link"): str,
-})
+STEP_VERIFY_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("verification_link"): str,
+    }
+)
 
-STEP_REAUTH_SCHEMA = vol.Schema({
-    vol.Required(CONF_EMAIL): str,
-    vol.Required(CONF_PASSWORD): str,
-})
+STEP_REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
 
 
 class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
@@ -53,35 +64,39 @@ class MyHondaPlusOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({
-                vol.Optional(
-                    CONF_SCAN_INTERVAL,
-                    default=get_entry_value(
-                        self.config_entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-                    ),
-                ): int,
-                vol.Optional(
-                    CONF_CAR_REFRESH_INTERVAL,
-                    default=get_entry_value(
-                        self.config_entry,
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=get_entry_value(
+                            self.config_entry,
+                            CONF_SCAN_INTERVAL,
+                            DEFAULT_SCAN_INTERVAL,
+                        ),
+                    ): int,
+                    vol.Optional(
                         CONF_CAR_REFRESH_INTERVAL,
-                        DEFAULT_CAR_REFRESH_INTERVAL,
-                    ),
-                ): int,
-                vol.Optional(
-                    CONF_LOCATION_REFRESH_INTERVAL,
-                    default=get_entry_value(
-                        self.config_entry,
+                        default=get_entry_value(
+                            self.config_entry,
+                            CONF_CAR_REFRESH_INTERVAL,
+                            DEFAULT_CAR_REFRESH_INTERVAL,
+                        ),
+                    ): int,
+                    vol.Optional(
                         CONF_LOCATION_REFRESH_INTERVAL,
-                        DEFAULT_LOCATION_REFRESH_INTERVAL,
-                    ),
-                ): int,
-            }),
+                        default=get_entry_value(
+                            self.config_entry,
+                            CONF_LOCATION_REFRESH_INTERVAL,
+                            DEFAULT_LOCATION_REFRESH_INTERVAL,
+                        ),
+                    ): int,
+                }
+            ),
         )
 
 
 class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 2
+    VERSION = 3
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -106,10 +121,15 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._email = user_input[CONF_EMAIL]
             self._password = user_input[CONF_PASSWORD]
-            self._scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-            self._car_refresh_interval = user_input.get(CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL)
+            self._scan_interval = user_input.get(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            )
+            self._car_refresh_interval = user_input.get(
+                CONF_CAR_REFRESH_INTERVAL, DEFAULT_CAR_REFRESH_INTERVAL
+            )
             self._location_refresh_interval = user_input.get(
-                CONF_LOCATION_REFRESH_INTERVAL, DEFAULT_LOCATION_REFRESH_INTERVAL,
+                CONF_LOCATION_REFRESH_INTERVAL,
+                DEFAULT_LOCATION_REFRESH_INTERVAL,
             )
 
             self._device_key = DeviceKey()
@@ -117,7 +137,9 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 self._tokens = await self.hass.async_add_executor_job(
-                    self._auth.login, self._email, self._password,
+                    self._auth.login,
+                    self._email,
+                    self._password,
                 )
                 return await self._fetch_vehicles_and_continue()
             except HondaAuthError as e:
@@ -126,7 +148,8 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     try:
                         await self.hass.async_add_executor_job(
                             self._auth.reset_device_authenticator,
-                            self._email, self._password,
+                            self._email,
+                            self._password,
                         )
                     except HondaAuthError as e2:
                         if "currently blocked" not in str(e2):
@@ -134,7 +157,10 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             return self._show_user_form(errors)
 
                     return await self.async_step_verify()
-                elif "invalid-credentials" in error_text.lower() or "INVALID_CREDS" in error_text:
+                elif (
+                    "invalid-credentials" in error_text.lower()
+                    or "INVALID_CREDS" in error_text
+                ):
                     errors["base"] = "invalid_auth"
                 elif "locked-account" in error_text.lower():
                     errors["base"] = "account_locked"
@@ -165,16 +191,19 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 self._tokens = await self.hass.async_add_executor_job(
-                    self._auth.login, self._email, self._password,
+                    self._auth.login,
+                    self._email,
+                    self._password,
                 )
-                return self._update_reauth_entry()
+                return await self._update_reauth_entry()
             except HondaAuthError as e:
                 error_text = str(e)
                 if "device-authenticator-not-registered" in error_text:
                     try:
                         await self.hass.async_add_executor_job(
                             self._auth.reset_device_authenticator,
-                            self._email, self._password,
+                            self._email,
+                            self._password,
                         )
                     except HondaAuthError as e2:
                         if "currently blocked" not in str(e2):
@@ -185,7 +214,10 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 errors=errors,
                             )
                     return await self.async_step_verify()
-                elif "invalid-credentials" in error_text.lower() or "INVALID_CREDS" in error_text:
+                elif (
+                    "invalid-credentials" in error_text.lower()
+                    or "INVALID_CREDS" in error_text
+                ):
                     errors["base"] = "invalid_auth"
                 elif "locked-account" in error_text.lower():
                     errors["base"] = "account_locked"
@@ -202,8 +234,8 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    def _update_reauth_entry(self):
-        """Update the existing config entry with new tokens."""
+    async def _update_reauth_entry(self):
+        """Update the existing config entry with new tokens and refreshed vehicle list."""
         user_id = HondaAuth.extract_user_id(self._tokens["access_token"])
         new_data = {
             **self._reauth_entry.data,
@@ -212,8 +244,26 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_USER_ID: user_id,
             CONF_DEVICE_KEY_PEM: self._device_key.pem_bytes.decode(),
         }
+
+        # Refresh vehicle list during reauth
+        api = HondaAPI()
+        api.set_tokens(
+            access_token=self._tokens["access_token"],
+            refresh_token=self._tokens["refresh_token"],
+            user_id=user_id,
+        )
+        try:
+            api_vehicles = await self.hass.async_add_executor_job(api.get_vehicles)
+            new_data[CONF_VEHICLES] = _reconcile_vehicles(
+                new_data.get(CONF_VEHICLES, []),
+                api_vehicles,
+            )
+        except Exception:
+            LOGGER.warning("Could not refresh vehicle list during reauth")
+
         self.hass.config_entries.async_update_entry(
-            self._reauth_entry, data=new_data,
+            self._reauth_entry,
+            data=new_data,
         )
         return self.async_abort(reason="reauth_successful")
 
@@ -235,12 +285,16 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_link"
             else:
                 await self.hass.async_add_executor_job(
-                    self._auth.verify_magic_link, key, link_type,
+                    self._auth.verify_magic_link,
+                    key,
+                    link_type,
                 )
 
                 try:
                     self._tokens = await self.hass.async_add_executor_job(
-                        self._auth.login, self._email, self._password,
+                        self._auth.login,
+                        self._email,
+                        self._password,
                     )
                     return await self._fetch_vehicles_and_continue()
                 except HondaAuthError as e:
@@ -254,12 +308,12 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _fetch_vehicles_and_continue(self):
-        """After login, fetch vehicles and go to selection or create entry.
+        """After login, fetch vehicles and create entry.
 
         During reauth, skip vehicle selection and just update tokens.
         """
         if self._reauth_entry is not None:
-            return self._update_reauth_entry()
+            return await self._update_reauth_entry()
         user_id = HondaAuth.extract_user_id(self._tokens["access_token"])
 
         self._api = HondaAPI()
@@ -277,55 +331,35 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             LOGGER.exception("Failed to fetch vehicles")
             self._vehicles = []
 
-        if len(self._vehicles) == 1:
-            return await self._create_entry(
-                self._vehicles[0]["vin"],
-                self._vehicles[0].get("name", ""),
-                self._vehicles[0].get("fuel_type", ""),
-            )
-
-        if len(self._vehicles) > 1:
-            return await self.async_step_select_vehicle()
+        if self._vehicles:
+            return await self._create_entry()
 
         # No vehicles found — fall back to manual VIN entry
         return await self.async_step_manual_vin()
 
-    async def async_step_select_vehicle(self, user_input=None):
-        """Let user pick a vehicle from their account."""
-        if user_input is not None:
-            vin = user_input[CONF_VIN]
-            vehicle = next((v for v in self._vehicles if v["vin"] == vin), {})
-            return await self._create_entry(
-                vin, vehicle.get("name", ""), vehicle.get("fuel_type", ""),
-            )
-
-        options = {
-            v["vin"]: f"{v.get('name') or v['vin']} ({v['plate']})"
-            if v.get("plate")
-            else v.get("name") or v["vin"]
-            for v in self._vehicles
-        }
-
-        return self.async_show_form(
-            step_id="select_vehicle",
-            data_schema=vol.Schema({
-                vol.Required(CONF_VIN): vol.In(options),
-            }),
-        )
-
     async def async_step_manual_vin(self, user_input=None):
         """Fallback: manual VIN entry if vehicle discovery fails."""
         if user_input is not None:
-            return await self._create_entry(user_input[CONF_VIN], "", "")
+            self._vehicles = [
+                {
+                    "vin": user_input[CONF_VIN],
+                    "name": "",
+                    "fuel_type": "",
+                    "manual": True,
+                }
+            ]
+            return await self._create_entry()
 
         return self.async_show_form(
             step_id="manual_vin",
-            data_schema=vol.Schema({
-                vol.Required(CONF_VIN): str,
-            }),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_VIN): str,
+                }
+            ),
         )
 
-    async def _create_entry(self, vin: str, vehicle_name: str, fuel_type: str):
+    async def _create_entry(self):
         user_id = HondaAuth.extract_user_id(self._tokens["access_token"])
 
         if self._api is None:
@@ -338,29 +372,38 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             info = await self.hass.async_add_executor_job(
-                self._api.get_user_info, user_id,
+                self._api.get_user_info,
+                user_id,
             )
             personal_id = str(info.get("personalId", ""))
         except Exception:
             personal_id = ""
 
-        await self.async_set_unique_id(vin)
+        await self.async_set_unique_id(self._email.lower())
         self._abort_if_unique_id_configured()
 
-        title = vehicle_name or f"Honda {vin[-6:]}"
+        vehicles = [
+            {
+                CONF_VIN: v["vin"],
+                CONF_VEHICLE_NAME: v.get("name", ""),
+                CONF_FUEL_TYPE: v.get("fuel_type", ""),
+                **({"manual": True} if v.get("manual") else {}),
+            }
+            for v in self._vehicles
+        ]
+
+        title = f"My Honda+ ({self._email})"
 
         return self.async_create_entry(
             title=title,
             data={
                 CONF_EMAIL: self._email,
-                CONF_VIN: vin,
-                CONF_VEHICLE_NAME: vehicle_name,
                 CONF_ACCESS_TOKEN: self._tokens["access_token"],
                 CONF_REFRESH_TOKEN: self._tokens["refresh_token"],
                 CONF_USER_ID: user_id,
                 CONF_PERSONAL_ID: personal_id,
                 CONF_DEVICE_KEY_PEM: self._device_key.pem_bytes.decode(),
-                CONF_FUEL_TYPE: fuel_type,
+                CONF_VEHICLES: vehicles,
             },
             options={
                 CONF_SCAN_INTERVAL: self._scan_interval,
@@ -368,3 +411,48 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_LOCATION_REFRESH_INTERVAL: self._location_refresh_interval,
             },
         )
+
+
+def _reconcile_vehicles(
+    existing: list[dict],
+    api_vehicles: list[dict],
+) -> list[dict]:
+    """Reconcile existing vehicle list with freshly discovered vehicles.
+
+    - New VINs from API → appended
+    - Existing VINs → name/fuel_type updated from API
+    - Manual VINs → always preserved
+    - VINs previously from API but no longer returned → removed
+    """
+    api_by_vin = {v["vin"]: v for v in api_vehicles}
+    result = []
+
+    for v in existing:
+        vin = v[CONF_VIN]
+        if v.get("manual"):
+            # Manual VINs always preserved
+            result.append(v)
+        elif vin in api_by_vin:
+            # Update name/fuel_type from API
+            api_v = api_by_vin.pop(vin)
+            result.append(
+                {
+                    **v,
+                    CONF_VEHICLE_NAME: api_v.get("name", v.get(CONF_VEHICLE_NAME, "")),
+                    CONF_FUEL_TYPE: api_v.get("fuel_type", v.get(CONF_FUEL_TYPE, "")),
+                }
+            )
+        # else: VIN no longer in API → removed
+
+    # Append newly discovered VINs
+    for vin, api_v in api_by_vin.items():
+        if not any(v[CONF_VIN] == vin for v in result):
+            result.append(
+                {
+                    CONF_VIN: vin,
+                    CONF_VEHICLE_NAME: api_v.get("name", ""),
+                    CONF_FUEL_TYPE: api_v.get("fuel_type", ""),
+                }
+            )
+
+    return result

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -156,6 +156,10 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         if "currently blocked" not in str(e2):
                             errors["base"] = "cannot_connect"
                             return self._show_user_form(errors)
+                    except Exception:
+                        LOGGER.exception("Device registration failed")
+                        errors["base"] = "cannot_connect"
+                        return self._show_user_form(errors)
 
                     return await self.async_step_verify()
                 elif (
@@ -214,6 +218,14 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 data_schema=STEP_REAUTH_SCHEMA,
                                 errors=errors,
                             )
+                    except Exception:
+                        LOGGER.exception("Device registration failed")
+                        errors["base"] = "cannot_connect"
+                        return self.async_show_form(
+                            step_id="reauth_confirm",
+                            data_schema=STEP_REAUTH_SCHEMA,
+                            errors=errors,
+                        )
                     return await self.async_step_verify()
                 elif (
                     "invalid-credentials" in error_text.lower()

--- a/custom_components/myhondaplus/config_flow.py
+++ b/custom_components/myhondaplus/config_flow.py
@@ -12,6 +12,7 @@ from .const import (
     CONF_DEVICE_KEY_PEM,
     CONF_FUEL_TYPE,
     CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_MODEL,
     CONF_PERSONAL_ID,
     CONF_REFRESH_TOKEN,
     CONF_USER_ID,
@@ -253,7 +254,8 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_id=user_id,
         )
         try:
-            api_vehicles = await self.hass.async_add_executor_job(api.get_vehicles)
+            user_info = await self.hass.async_add_executor_job(api.get_user_info)
+            api_vehicles = _parse_vehicles(user_info)
             new_data[CONF_VEHICLES] = _reconcile_vehicles(
                 new_data.get(CONF_VEHICLES, []),
                 api_vehicles,
@@ -324,11 +326,14 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         try:
-            self._vehicles = await self.hass.async_add_executor_job(
-                self._api.get_vehicles,
+            user_info = await self.hass.async_add_executor_job(
+                self._api.get_user_info,
             )
+            self._personal_id = str(user_info.get("personalId", ""))
+            self._vehicles = _parse_vehicles(user_info)
         except Exception:
             LOGGER.exception("Failed to fetch vehicles")
+            self._personal_id = ""
             self._vehicles = []
 
         if self._vehicles:
@@ -370,14 +375,16 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_id=user_id,
             )
 
-        try:
-            info = await self.hass.async_add_executor_job(
-                self._api.get_user_info,
-                user_id,
-            )
-            personal_id = str(info.get("personalId", ""))
-        except Exception:
-            personal_id = ""
+        personal_id = getattr(self, "_personal_id", "") or ""
+        if not personal_id:
+            try:
+                info = await self.hass.async_add_executor_job(
+                    self._api.get_user_info,
+                    user_id,
+                )
+                personal_id = str(info.get("personalId", ""))
+            except Exception:
+                personal_id = ""
 
         await self.async_set_unique_id(self._email.lower())
         self._abort_if_unique_id_configured()
@@ -387,6 +394,7 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_VIN: v["vin"],
                 CONF_VEHICLE_NAME: v.get("name", ""),
                 CONF_FUEL_TYPE: v.get("fuel_type", ""),
+                CONF_MODEL: v.get("model", ""),
                 **({"manual": True} if v.get("manual") else {}),
             }
             for v in self._vehicles
@@ -413,6 +421,41 @@ class MyHondaPlusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
+def _build_model_name(v: dict) -> str:
+    """Build a display model name from raw vehiclesInfo fields."""
+    ui = v.get("vehicleUIConfiguration", {})
+    friendly = ui.get("friendlyModelName", "")
+    grade = v.get("grade", "")
+    year = v.get("modelYear")
+
+    if friendly and grade:
+        parts = grade.split(None, 1)
+        grade = (
+            parts[1].title() if len(parts) > 1 and len(parts[0]) <= 2 else grade.title()
+        )
+
+    name = friendly
+    if grade:
+        name = f"{name} {grade}" if name else grade
+    if year:
+        name = f"{name} ({year})" if name else str(year)
+    return name
+
+
+def _parse_vehicles(user_info: dict) -> list[dict]:
+    """Parse vehiclesInfo from get_user_info into our vehicle format."""
+    return [
+        {
+            "vin": v["vin"],
+            "name": v.get("vehicleNickName", ""),
+            "fuel_type": v.get("fuelType", ""),
+            "model": _build_model_name(v),
+        }
+        for v in user_info.get("vehiclesInfo", [])
+        if "vin" in v
+    ]
+
+
 def _reconcile_vehicles(
     existing: list[dict],
     api_vehicles: list[dict],
@@ -420,7 +463,7 @@ def _reconcile_vehicles(
     """Reconcile existing vehicle list with freshly discovered vehicles.
 
     - New VINs from API → appended
-    - Existing VINs → name/fuel_type updated from API
+    - Existing VINs → name/fuel_type/model updated from API
     - Manual VINs → always preserved
     - VINs previously from API but no longer returned → removed
     """
@@ -440,6 +483,7 @@ def _reconcile_vehicles(
                     **v,
                     CONF_VEHICLE_NAME: api_v.get("name", v.get(CONF_VEHICLE_NAME, "")),
                     CONF_FUEL_TYPE: api_v.get("fuel_type", v.get(CONF_FUEL_TYPE, "")),
+                    CONF_MODEL: api_v.get("model", v.get(CONF_MODEL, "")),
                 }
             )
         # else: VIN no longer in API → removed
@@ -452,6 +496,7 @@ def _reconcile_vehicles(
                     CONF_VIN: vin,
                     CONF_VEHICLE_NAME: api_v.get("name", ""),
                     CONF_FUEL_TYPE: api_v.get("fuel_type", ""),
+                    CONF_MODEL: api_v.get("model", ""),
                 }
             )
 

--- a/custom_components/myhondaplus/const.py
+++ b/custom_components/myhondaplus/const.py
@@ -13,6 +13,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DEVICE_KEY_PEM = "device_key_pem"
 CONF_VEHICLE_NAME = "vehicle_name"
 CONF_FUEL_TYPE = "fuel_type"
+CONF_VEHICLES = "vehicles"
 
 CONF_CAR_REFRESH_INTERVAL = "car_refresh_interval"
 CONF_LOCATION_REFRESH_INTERVAL = "location_refresh_interval"

--- a/custom_components/myhondaplus/const.py
+++ b/custom_components/myhondaplus/const.py
@@ -13,6 +13,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DEVICE_KEY_PEM = "device_key_pem"
 CONF_VEHICLE_NAME = "vehicle_name"
 CONF_FUEL_TYPE = "fuel_type"
+CONF_MODEL = "model"
 CONF_VEHICLES = "vehicles"
 
 CONF_CAR_REFRESH_INTERVAL = "car_refresh_interval"

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -1,5 +1,6 @@
 """Data coordinator for My Honda+."""
 
+from dataclasses import dataclass, field, fields
 from datetime import timedelta
 
 from homeassistant.components.persistent_notification import (
@@ -10,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pymyhondaplus.api import (
+    EVStatus,
     HondaAPI,
     HondaAPIError,
     HondaAuthError,
@@ -31,11 +33,19 @@ from .const import (
 from .entry_options import get_entry_value
 
 
+@dataclass
+class DashboardData(EVStatus):
+    """Vehicle dashboard data: EVStatus fields plus parsed schedules."""
+
+    charge_schedule: list[dict] = field(default_factory=list)
+    climate_schedule: list[dict] = field(default_factory=list)
+
+
 def _handle_api_error(
     err: HondaAPIError,
     persist_tokens: callable,
-    cached_data: dict | None = None,
-) -> dict | None:
+    cached_data=None,
+):
     """Handle HondaAPIError consistently across coordinators.
 
     Returns cached data for transient 5xx errors, raises
@@ -49,7 +59,7 @@ def _handle_api_error(
     return None
 
 
-class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
+class HondaDataUpdateCoordinator(DataUpdateCoordinator[DashboardData]):
     def __init__(
         self,
         hass: HomeAssistant,
@@ -85,12 +95,15 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             }
             self.hass.config_entries.async_update_entry(self.entry, data=new_data)
 
-    def _fetch_data(self) -> dict:
+    def _fetch_data(self) -> DashboardData:
         dashboard = self.api.get_dashboard_cached(self.vin)
-        data = parse_ev_status(dashboard)
-        data["charge_schedule"] = parse_charge_schedule(dashboard)
-        data["climate_schedule"] = parse_climate_schedule(dashboard)
-        return data
+        ev = parse_ev_status(dashboard)
+        ev_values = {f.name: getattr(ev, f.name) for f in fields(ev)}
+        return DashboardData(
+            **ev_values,
+            charge_schedule=parse_charge_schedule(dashboard),
+            climate_schedule=parse_climate_schedule(dashboard),
+        )
 
     def _log_unavailable_once(self, message: str, *args) -> None:
         """Log when the Honda service becomes unavailable."""
@@ -104,7 +117,7 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             LOGGER.info("Connection to Honda API restored")
             self._service_available = True
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> DashboardData:
         try:
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
@@ -305,7 +318,7 @@ class HondaTripCoordinator(DataUpdateCoordinator[dict]):
         rows = self.api.get_all_trips(self.vin)
         distance_unit = "km"
         if self._main_coordinator and self._main_coordinator.data:
-            distance_unit = self._main_coordinator.data.get("distance_unit", "km")
+            distance_unit = self._main_coordinator.data.distance_unit
         return compute_trip_stats(
             rows,
             "month",

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -188,6 +188,11 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[DashboardData]):
     async def async_send_command(self, func, *args) -> str:
         try:
             result = await self.hass.async_add_executor_job(func, *args)
+        except ValueError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="capability_not_supported",
+            ) from err
         except HondaAPIError as err:
             _handle_api_error(err, self._persist_tokens_if_changed)
             LOGGER.error("Remote command failed: %s", err)

--- a/custom_components/myhondaplus/coordinator.py
+++ b/custom_components/myhondaplus/coordinator.py
@@ -21,13 +21,8 @@ from pymyhondaplus.api import (
 
 from .const import (
     CONF_ACCESS_TOKEN,
-    CONF_FUEL_TYPE,
-    CONF_PERSONAL_ID,
     CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
-    CONF_USER_ID,
-    CONF_VEHICLE_NAME,
-    CONF_VIN,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TRIP_INTERVAL,
     DOMAIN,
@@ -55,39 +50,39 @@ def _handle_api_error(
 
 
 class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        api: HondaAPI,
+        vin: str,
+        vehicle_name: str = "",
+    ) -> None:
         self.entry = entry
-        self.vin: str = entry.data[CONF_VIN]
-        self._vehicle_name: str = entry.data.get(CONF_VEHICLE_NAME, "")
-        self.api = HondaAPI()
+        self.vin: str = vin
+        self._vehicle_name: str = vehicle_name
+        self.api = api
         self._service_available = True
-        self._apply_tokens()
 
         interval = get_entry_value(entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             LOGGER,
-            name=DOMAIN,
+            name=f"{DOMAIN}_{vin[-6:]}",
             update_interval=timedelta(seconds=interval),
-        )
-
-    def _apply_tokens(self) -> None:
-        self.api.set_tokens(
-            access_token=self.entry.data[CONF_ACCESS_TOKEN],
-            refresh_token=self.entry.data[CONF_REFRESH_TOKEN],
-            personal_id=self.entry.data.get(CONF_PERSONAL_ID, ""),
-            user_id=self.entry.data.get(CONF_USER_ID, ""),
         )
 
     def _persist_tokens_if_changed(self) -> None:
         tokens = self.api.tokens
         data = self.entry.data
-        if (tokens.access_token != data.get(CONF_ACCESS_TOKEN)
-                or tokens.refresh_token != data.get(CONF_REFRESH_TOKEN)):
-            new_data = {**data,
-                        CONF_ACCESS_TOKEN: tokens.access_token,
-                        CONF_REFRESH_TOKEN: tokens.refresh_token}
+        if tokens.access_token != data.get(
+            CONF_ACCESS_TOKEN
+        ) or tokens.refresh_token != data.get(CONF_REFRESH_TOKEN):
+            new_data = {
+                **data,
+                CONF_ACCESS_TOKEN: tokens.access_token,
+                CONF_REFRESH_TOKEN: tokens.refresh_token,
+            }
             self.hass.config_entries.async_update_entry(self.entry, data=new_data)
 
     def _fetch_data(self) -> dict:
@@ -114,7 +109,9 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
             cached = _handle_api_error(
-                err, self._persist_tokens_if_changed, self.data,
+                err,
+                self._persist_tokens_if_changed,
+                self.data,
             )
             if cached is not None:
                 self._log_unavailable_once(
@@ -189,14 +186,20 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         return result
 
     async def async_send_command_and_wait(
-        self, func, *args, timeout: int = 90, notify_on_timeout: bool = True,
+        self,
+        func,
+        *args,
+        timeout: int = 90,
+        notify_on_timeout: bool = True,
     ) -> bool:
         """Send a command and wait for confirmation. Raises on send failure."""
         command_id = await self.async_send_command(func, *args)
         if not command_id:
             return False
         result = await self.hass.async_add_executor_job(
-            self.api.wait_for_command, command_id, timeout,
+            self.api.wait_for_command,
+            command_id,
+            timeout,
         )
         if not result.success:
             if result.timed_out:
@@ -226,10 +229,13 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
         """Request fresh GPS location from the car and update dashboard."""
         try:
             command_id = await self.async_send_command(
-                self.api.request_car_location, self.vin,
+                self.api.request_car_location,
+                self.vin,
             )
             result = await self.hass.async_add_executor_job(
-                self.api.wait_for_command, command_id, 90,
+                self.api.wait_for_command,
+                command_id,
+                90,
             )
             if not result.success:
                 if result.timed_out:
@@ -270,27 +276,28 @@ class HondaDataUpdateCoordinator(DataUpdateCoordinator[dict]):
 
 
 class HondaTripCoordinator(DataUpdateCoordinator[dict]):
-
     def __init__(
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
         api: HondaAPI,
         persist_tokens: callable,
+        vin: str,
+        fuel_type: str = "",
         main_coordinator: HondaDataUpdateCoordinator | None = None,
     ) -> None:
         self.entry = entry
-        self.vin: str = entry.data[CONF_VIN]
+        self.vin: str = vin
         self.api = api
         self._persist_tokens = persist_tokens
         self._main_coordinator = main_coordinator
-        self._fuel_type: str = entry.data.get(CONF_FUEL_TYPE, "")
+        self._fuel_type: str = fuel_type
         self._service_available = True
 
         super().__init__(
             hass,
             LOGGER,
-            name=f"{DOMAIN}_trips",
+            name=f"{DOMAIN}_trips_{vin[-6:]}",
             update_interval=timedelta(seconds=DEFAULT_TRIP_INTERVAL),
         )
 
@@ -300,7 +307,10 @@ class HondaTripCoordinator(DataUpdateCoordinator[dict]):
         if self._main_coordinator and self._main_coordinator.data:
             distance_unit = self._main_coordinator.data.get("distance_unit", "km")
         return compute_trip_stats(
-            rows, "month", fuel_type=self._fuel_type, distance_unit=distance_unit,
+            rows,
+            "month",
+            fuel_type=self._fuel_type,
+            distance_unit=distance_unit,
         )
 
     def _log_unavailable_once(self, message: str, *args) -> None:
@@ -320,7 +330,9 @@ class HondaTripCoordinator(DataUpdateCoordinator[dict]):
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except HondaAPIError as err:
             cached = _handle_api_error(
-                err, self._persist_tokens, self.data,
+                err,
+                self._persist_tokens,
+                self.data,
             )
             if cached is not None:
                 self._log_unavailable_once(

--- a/custom_components/myhondaplus/data.py
+++ b/custom_components/myhondaplus/data.py
@@ -9,17 +9,30 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 
 if TYPE_CHECKING:
+    from pymyhondaplus.api import HondaAPI
+
     from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 
 type MyHondaPlusConfigEntry = ConfigEntry[MyHondaPlusData]
 
 
 @dataclass
-class MyHondaPlusData:
-    """Data for the My Honda+ integration."""
+class VehicleData:
+    """Data for a single vehicle."""
 
     coordinator: HondaDataUpdateCoordinator
     trip_coordinator: HondaTripCoordinator
+    vin: str
+    vehicle_name: str = ""
+    fuel_type: str = ""
     car_refresh_unsub: CALLBACK_TYPE | None = field(default=None)
     car_refresh_enabled: bool = field(default=True)
     location_refresh_unsub: CALLBACK_TYPE | None = field(default=None)
+
+
+@dataclass
+class MyHondaPlusData:
+    """Data for the My Honda+ integration."""
+
+    vehicles: dict[str, VehicleData]
+    api: HondaAPI

--- a/custom_components/myhondaplus/data.py
+++ b/custom_components/myhondaplus/data.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
+from pymyhondaplus.api import UIConfiguration, VehicleCapabilities
 
 if TYPE_CHECKING:
     from pymyhondaplus.api import HondaAPI
@@ -14,6 +15,24 @@ if TYPE_CHECKING:
     from .coordinator import HondaDataUpdateCoordinator, HondaTripCoordinator
 
 type MyHondaPlusConfigEntry = ConfigEntry[MyHondaPlusData]
+
+
+def _all_capable() -> VehicleCapabilities:
+    """Return capabilities with everything enabled (safe default)."""
+    return VehicleCapabilities(
+        remote_lock=True,
+        remote_climate=True,
+        remote_charge=True,
+        remote_horn=True,
+        digital_key=True,
+        charge_schedule=True,
+        climate_schedule=True,
+        max_charge=True,
+        car_finder=True,
+        journey_history=True,
+        send_poi=True,
+        geo_fence=True,
+    )
 
 
 @dataclass
@@ -25,6 +44,8 @@ class VehicleData:
     vin: str
     vehicle_name: str = ""
     fuel_type: str = ""
+    capabilities: VehicleCapabilities = field(default_factory=_all_capable)
+    ui_config: UIConfiguration = field(default_factory=UIConfiguration)
     car_refresh_unsub: CALLBACK_TYPE | None = field(default=None)
     car_refresh_enabled: bool = field(default=True)
     location_refresh_unsub: CALLBACK_TYPE | None = field(default=None)

--- a/custom_components/myhondaplus/device_tracker.py
+++ b/custom_components/myhondaplus/device_tracker.py
@@ -5,7 +5,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity
 
@@ -18,10 +17,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ device tracker."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities([HondaDeviceTracker(coordinator, vin, vehicle_name)])
+    async_add_entities(
+        HondaDeviceTracker(v.coordinator, v.vin, v.vehicle_name, v.fuel_type)
+        for v in entry.runtime_data.vehicles.values()
+    )
 
 
 def _dms_to_decimal(value) -> float | None:
@@ -55,12 +54,14 @@ class HondaDeviceTracker(MyHondaPlusEntity, TrackerEntity):
 
     _attr_translation_key = "vehicle_location"
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = EntityDescription(
             key="vehicle_location",
             translation_key="vehicle_location",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def source_type(self) -> SourceType:

--- a/custom_components/myhondaplus/device_tracker.py
+++ b/custom_components/myhondaplus/device_tracker.py
@@ -70,8 +70,8 @@ class HondaDeviceTracker(MyHondaPlusEntity, TrackerEntity):
 
     @property
     def latitude(self) -> float | None:
-        return _dms_to_decimal(self.coordinator.data.get("latitude"))
+        return _dms_to_decimal(self.coordinator.data.latitude)
 
     @property
     def longitude(self) -> float | None:
-        return _dms_to_decimal(self.coordinator.data.get("longitude"))
+        return _dms_to_decimal(self.coordinator.data.longitude)

--- a/custom_components/myhondaplus/device_tracker.py
+++ b/custom_components/myhondaplus/device_tracker.py
@@ -20,6 +20,7 @@ async def async_setup_entry(
     async_add_entities(
         HondaDeviceTracker(v.coordinator, v.vin, v.vehicle_name, v.fuel_type)
         for v in entry.runtime_data.vehicles.values()
+        if v.capabilities.car_finder
     )
 
 

--- a/custom_components/myhondaplus/diagnostics.py
+++ b/custom_components/myhondaplus/diagnostics.py
@@ -28,10 +28,13 @@ async def async_get_config_entry_diagnostics(
     entry: MyHondaPlusConfigEntry,
 ) -> dict:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data.coordinator
-    trip_coordinator = entry.runtime_data.trip_coordinator
+    vehicles_diag = {}
+    for vin, vd in entry.runtime_data.vehicles.items():
+        vehicles_diag[vin] = {
+            "coordinator_data": vd.coordinator.data,
+            "trip_data": vd.trip_coordinator.data,
+        }
     return {
         "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "coordinator_data": coordinator.data,
-        "trip_data": trip_coordinator.data,
+        "vehicles": vehicles_diag,
     }

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -22,14 +22,6 @@ def to_bool(value) -> bool | None:
     return bool(value)
 
 
-FUEL_TYPE_LABELS = {
-    "E": "Electric",
-    "H": "Hybrid",
-    "G": "Gasoline",
-    "D": "Diesel",
-}
-
-
 class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
     """Base class for My Honda+ entities."""
 
@@ -55,15 +47,11 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
-        info = DeviceInfo(
+        return DeviceInfo(
             identifiers={(DOMAIN, self._vin)},
             name=self._vehicle_name or f"Honda {self._vin[-6:]}",
             manufacturer="Honda",
         )
-        model = FUEL_TYPE_LABELS.get(self._fuel_type)
-        if model:
-            info["model"] = model
-        return info
 
     def _schedule_refresh(self, delay: int = 30) -> None:
         """Schedule a coordinator refresh, replacing any pending one."""

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN
+from .coordinator import DashboardData
 
 
 def to_bool(value) -> bool | None:
@@ -22,7 +23,7 @@ def to_bool(value) -> bool | None:
     return bool(value)
 
 
-class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
+class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[DashboardData]]):
     """Base class for My Honda+ entities."""
 
     _attr_has_entity_name = True

--- a/custom_components/myhondaplus/entity.py
+++ b/custom_components/myhondaplus/entity.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import CONF_FUEL_TYPE, DOMAIN
+from .const import DOMAIN
 
 
 def to_bool(value) -> bool | None:
@@ -20,6 +20,7 @@ def to_bool(value) -> bool | None:
     if isinstance(value, str):
         return value.lower() in ("true", "on", "yes", "1", "locked")
     return bool(value)
+
 
 FUEL_TYPE_LABELS = {
     "E": "Electric",
@@ -41,6 +42,7 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
         description,
         vin: str,
         vehicle_name: str = "",
+        fuel_type: str = "",
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
@@ -48,7 +50,7 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
         self._attr_unique_id = f"{vin}_{description.key}"
         self._vin = vin
         self._vehicle_name = vehicle_name
-        self._fuel_type = coordinator.entry.data.get(CONF_FUEL_TYPE, "")
+        self._fuel_type = fuel_type
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -68,7 +70,9 @@ class MyHondaPlusEntity(CoordinatorEntity[DataUpdateCoordinator[dict]]):
         if self._refresh_unsub:
             self._refresh_unsub()
         self._refresh_unsub = async_call_later(
-            self.hass, delay, self._do_refresh,
+            self.hass,
+            delay,
+            self._do_refresh,
         )
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -4,7 +4,6 @@ from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity, to_bool
 
@@ -17,10 +16,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ locks."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities([HondaDoorLock(coordinator, vin, vehicle_name)])
+    async_add_entities(
+        HondaDoorLock(v.coordinator, v.vin, v.vehicle_name, v.fuel_type)
+        for v in entry.runtime_data.vehicles.values()
+    )
 
 
 class HondaDoorLock(MyHondaPlusEntity, LockEntity):
@@ -28,12 +27,14 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
 
     _attr_translation_key = "doors"
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = LockEntityDescription(
             key="doors",
             translation_key="doors",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def is_locked(self) -> bool | None:
@@ -47,7 +48,8 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         self.async_write_ha_state()
         try:
             confirmed = await self.coordinator.async_send_command_and_wait(
-                self.coordinator.api.remote_lock, self._vin,
+                self.coordinator.api.remote_lock,
+                self._vin,
             )
             if confirmed:
                 data = dict(self.coordinator.data)
@@ -63,7 +65,8 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
         self.async_write_ha_state()
         try:
             confirmed = await self.coordinator.async_send_command_and_wait(
-                self.coordinator.api.remote_unlock, self._vin,
+                self.coordinator.api.remote_unlock,
+                self._vin,
             )
             if confirmed:
                 data = dict(self.coordinator.data)

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -19,6 +19,7 @@ async def async_setup_entry(
     async_add_entities(
         HondaDoorLock(v.coordinator, v.vin, v.vehicle_name, v.fuel_type)
         for v in entry.runtime_data.vehicles.values()
+        if v.capabilities.remote_lock
     )
 
 

--- a/custom_components/myhondaplus/lock.py
+++ b/custom_components/myhondaplus/lock.py
@@ -1,5 +1,7 @@
 """Lock platform for My Honda+."""
 
+from dataclasses import replace
+
 from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -40,8 +42,7 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
     @property
     def is_locked(self) -> bool | None:
         """Return true if doors are locked."""
-        value = self.coordinator.data.get("doors_locked")
-        return to_bool(value)
+        return to_bool(self.coordinator.data.doors_locked)
 
     async def async_lock(self, **kwargs) -> None:
         """Lock the doors."""
@@ -53,9 +54,9 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
                 self._vin,
             )
             if confirmed:
-                data = dict(self.coordinator.data)
-                data["doors_locked"] = True
-                self.coordinator.async_set_updated_data(data)
+                self.coordinator.async_set_updated_data(
+                    replace(self.coordinator.data, doors_locked=True)
+                )
         finally:
             self._attr_is_locking = False
             self.async_write_ha_state()
@@ -70,9 +71,9 @@ class HondaDoorLock(MyHondaPlusEntity, LockEntity):
                 self._vin,
             )
             if confirmed:
-                data = dict(self.coordinator.data)
-                data["doors_locked"] = False
-                self.coordinator.async_set_updated_data(data)
+                self.coordinator.async_set_updated_data(
+                    replace(self.coordinator.data, doors_locked=False)
+                )
         finally:
             self._attr_is_unlocking = False
             self.async_write_ha_state()

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.3.1"],
+  "requirements": ["pymyhondaplus==5.4.0"],
   "version": "4.5.0"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.6.1"],
+  "requirements": ["pymyhondaplus==5.6.3"],
   "version": "5.0.0-beta.4"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.4.0"],
-  "version": "5.0.0-beta.2"
+  "version": "5.0.0-beta.3"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.4.0"],
-  "version": "5.0.0-beta.1"
+  "version": "5.0.0-beta.2"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.4.0"],
+  "requirements": ["pymyhondaplus==5.6.1"],
   "version": "5.0.0-beta.3"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.6.3"],
-  "version": "5.0.0-beta.4"
+  "version": "5.0.0"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.6.1"],
-  "version": "5.0.0-beta.3"
+  "version": "5.0.0-beta.4"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.4.0"],
-  "version": "4.5.0"
+  "version": "5.0.0-beta.1"
 }

--- a/custom_components/myhondaplus/number.py
+++ b/custom_components/myhondaplus/number.py
@@ -51,12 +51,13 @@ async def async_setup_entry(
     """Set up My Honda+ charge limit numbers."""
     entities = []
     for v in entry.runtime_data.vehicles.values():
-        entities.extend(
-            HondaChargeLimitNumber(
-                v.coordinator, desc, v.vin, v.vehicle_name, v.fuel_type
+        if v.capabilities.remote_charge and v.capabilities.max_charge:
+            entities.extend(
+                HondaChargeLimitNumber(
+                    v.coordinator, desc, v.vin, v.vehicle_name, v.fuel_type
+                )
+                for desc in NUMBER_DESCRIPTIONS
             )
-            for desc in NUMBER_DESCRIPTIONS
-        )
     async_add_entities(entities)
 
 

--- a/custom_components/myhondaplus/number.py
+++ b/custom_components/myhondaplus/number.py
@@ -8,7 +8,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity
 
@@ -50,13 +49,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ charge limit numbers."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities(
-        HondaChargeLimitNumber(coordinator, description, vin, vehicle_name)
-        for description in NUMBER_DESCRIPTIONS
-    )
+    entities = []
+    for v in entry.runtime_data.vehicles.values():
+        entities.extend(
+            HondaChargeLimitNumber(
+                v.coordinator, desc, v.vin, v.vehicle_name, v.fuel_type
+            )
+            for desc in NUMBER_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
@@ -84,7 +85,10 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
             away = int(value)
 
         confirmed = await self.coordinator.async_send_command_and_wait(
-            self.coordinator.api.set_charge_limit, self._vin, home, away,
+            self.coordinator.api.set_charge_limit,
+            self._vin,
+            home,
+            away,
         )
         if confirmed:
             new_data = dict(self.coordinator.data)

--- a/custom_components/myhondaplus/number.py
+++ b/custom_components/myhondaplus/number.py
@@ -1,6 +1,6 @@
 """Number platform for My Honda+ (charge limits)."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import PERCENTAGE
@@ -68,7 +68,7 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
 
     @property
     def native_value(self) -> float | None:
-        val = self.coordinator.data.get(self.entity_description.key)
+        val = getattr(self.coordinator.data, self.entity_description.key, None)
         return float(val) if val is not None else None
 
     @property
@@ -76,9 +76,9 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
         return False
 
     async def async_set_native_value(self, value: float) -> None:
-        data = self.coordinator.data or {}
-        home = data.get("charge_limit_home", 80)
-        away = data.get("charge_limit_away", 90)
+        data = self.coordinator.data
+        home = data.charge_limit_home
+        away = data.charge_limit_away
 
         if self.entity_description.limit_key == "home":
             home = int(value)
@@ -92,6 +92,6 @@ class HondaChargeLimitNumber(MyHondaPlusEntity, NumberEntity):
             away,
         )
         if confirmed:
-            new_data = dict(self.coordinator.data)
-            new_data[self.entity_description.key] = int(value)
-            self.coordinator.async_set_updated_data(new_data)
+            self.coordinator.async_set_updated_data(
+                replace(data, **{self.entity_description.key: int(value)})
+            )

--- a/custom_components/myhondaplus/select.py
+++ b/custom_components/myhondaplus/select.py
@@ -5,7 +5,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity
 
@@ -21,13 +20,19 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ select entities."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities([
-        HondaClimateTempSelect(coordinator, vin, vehicle_name),
-        HondaClimateDurationSelect(coordinator, vin, vehicle_name),
-    ])
+    entities = []
+    for v in entry.runtime_data.vehicles.values():
+        entities.extend(
+            [
+                HondaClimateTempSelect(
+                    v.coordinator, v.vin, v.vehicle_name, v.fuel_type
+                ),
+                HondaClimateDurationSelect(
+                    v.coordinator, v.vin, v.vehicle_name, v.fuel_type
+                ),
+            ]
+        )
+    async_add_entities(entities)
 
 
 class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
@@ -38,12 +43,14 @@ class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
     _attr_options = CLIMATE_TEMP_OPTIONS
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = SelectEntityDescription(
             key="climate_temp_setting",
             translation_key="climate_temp_setting",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def current_option(self) -> str | None:
@@ -61,7 +68,10 @@ class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
         defrost = data.get("climate_defrost", True)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
-            self._vin, option, duration, defrost,
+            self._vin,
+            option,
+            duration,
+            defrost,
         )
         if confirmed:
             new_data = dict(self.coordinator.data)
@@ -77,12 +87,14 @@ class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
     _attr_options = CLIMATE_DURATION_OPTIONS
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = SelectEntityDescription(
             key="climate_duration_setting",
             translation_key="climate_duration_setting",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def current_option(self) -> str | None:
@@ -101,7 +113,10 @@ class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
         duration = int(option)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
-            self._vin, temp, duration, defrost,
+            self._vin,
+            temp,
+            duration,
+            defrost,
         )
         if confirmed:
             new_data = dict(self.coordinator.data)

--- a/custom_components/myhondaplus/select.py
+++ b/custom_components/myhondaplus/select.py
@@ -1,5 +1,7 @@
 """Select platform for My Honda+."""
 
+from dataclasses import replace
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -55,18 +57,18 @@ class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        value = self.coordinator.data.get("climate_temp")
+        value = self.coordinator.data.climate_temp
         if value in CLIMATE_TEMP_OPTIONS:
             return value
         return "normal"
 
     async def async_select_option(self, option: str) -> None:
         """Update climate temperature setting on the vehicle."""
-        data = self.coordinator.data or {}
-        duration = data.get("climate_duration", 30)
+        data = self.coordinator.data
+        duration = data.climate_duration
         if duration not in (10, 20, 30):
             duration = 30
-        defrost = data.get("climate_defrost", True)
+        defrost = data.climate_defrost
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
             self._vin,
@@ -75,9 +77,9 @@ class HondaClimateTempSelect(MyHondaPlusEntity, SelectEntity):
             defrost,
         )
         if confirmed:
-            new_data = dict(self.coordinator.data)
-            new_data["climate_temp"] = option
-            self.coordinator.async_set_updated_data(new_data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, climate_temp=option)
+            )
 
 
 class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
@@ -99,18 +101,18 @@ class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        value = self.coordinator.data.get("climate_duration")
+        value = self.coordinator.data.climate_duration
         if value in (10, 20, 30):
             return str(value)
         return "30"
 
     async def async_select_option(self, option: str) -> None:
         """Update climate duration setting on the vehicle."""
-        data = self.coordinator.data or {}
-        temp = data.get("climate_temp", "normal")
+        data = self.coordinator.data
+        temp = data.climate_temp
         if temp not in CLIMATE_TEMP_OPTIONS:
             temp = "normal"
-        defrost = data.get("climate_defrost", True)
+        defrost = data.climate_defrost
         duration = int(option)
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
@@ -120,6 +122,6 @@ class HondaClimateDurationSelect(MyHondaPlusEntity, SelectEntity):
             defrost,
         )
         if confirmed:
-            new_data = dict(self.coordinator.data)
-            new_data["climate_duration"] = duration
-            self.coordinator.async_set_updated_data(new_data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, climate_duration=duration)
+            )

--- a/custom_components/myhondaplus/select.py
+++ b/custom_components/myhondaplus/select.py
@@ -22,16 +22,17 @@ async def async_setup_entry(
     """Set up My Honda+ select entities."""
     entities = []
     for v in entry.runtime_data.vehicles.values():
-        entities.extend(
-            [
-                HondaClimateTempSelect(
-                    v.coordinator, v.vin, v.vehicle_name, v.fuel_type
-                ),
-                HondaClimateDurationSelect(
-                    v.coordinator, v.vin, v.vehicle_name, v.fuel_type
-                ),
-            ]
-        )
+        if v.capabilities.remote_climate and not v.ui_config.hide_climate_settings:
+            entities.extend(
+                [
+                    HondaClimateTempSelect(
+                        v.coordinator, v.vin, v.vehicle_name, v.fuel_type
+                    ),
+                    HondaClimateDurationSelect(
+                        v.coordinator, v.vin, v.vehicle_name, v.fuel_type
+                    ),
+                ]
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -31,6 +31,8 @@ UNIT_MAP = {
 @dataclass(frozen=True, kw_only=True)
 class HondaSensorDescription(SensorEntityDescription):
     dynamic_unit: str = ""
+    capability: str = ""
+    ui_hide: str = ""
 
 
 SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
@@ -40,6 +42,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="range_climate_on",
@@ -48,6 +51,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:map-marker-distance",
         dynamic_unit="distance",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="range_climate_off",
@@ -56,6 +60,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:map-marker-distance",
         dynamic_unit="distance",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="total_range",
@@ -71,6 +76,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.ENUM,
         options=["stopped", "charging", "complete", "notcharging", "unknown"],
         icon="mdi:ev-station",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="plug_status",
@@ -78,6 +84,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.ENUM,
         options=["plugged_in", "connected", "unplugged", "disconnected", "unknown"],
         icon="mdi:power-plug",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="home_away",
@@ -90,6 +97,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         key="climate_active",
         translation_key="climate_active",
         icon="mdi:air-conditioner",
+        capability="remote_climate",
     ),
     HondaSensorDescription(
         key="cabin_temp",
@@ -136,6 +144,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
             "unknown",
         ],
         icon="mdi:ev-station",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="time_to_charge",
@@ -144,6 +153,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:battery-clock",
+        capability="remote_charge",
     ),
     HondaSensorDescription(
         key="interior_temp",
@@ -151,6 +161,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         dynamic_unit="temp",
+        ui_hide="hide_internal_temperature",
     ),
     HondaSensorDescription(
         key="headlights",
@@ -180,6 +191,7 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.ENUM,
         options=["cooler", "normal", "hotter", "unknown"],
         icon="mdi:thermometer",
+        capability="remote_climate",
     ),
     HondaSensorDescription(
         key="climate_duration",
@@ -188,23 +200,27 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:timer-outline",
+        capability="remote_climate",
     ),
     HondaSensorDescription(
         key="climate_defrost",
         translation_key="climate_defrost",
         icon="mdi:car-defrost-rear",
+        capability="remote_climate",
     ),
     HondaSensorDescription(
         key="charge_schedule",
         translation_key="charge_schedule",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
+        capability="charge_schedule",
     ),
     HondaSensorDescription(
         key="climate_schedule",
         translation_key="climate_schedule",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
+        capability="climate_schedule",
     ),
 ]
 
@@ -241,6 +257,17 @@ TRIP_SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
 ]
 
 
+def _sensor_enabled(
+    desc: HondaSensorDescription, vehicle,
+) -> bool:
+    """Check if a sensor should be created based on capabilities and UI config."""
+    if desc.capability and not getattr(vehicle.capabilities, desc.capability, True):
+        return False
+    if desc.ui_hide and getattr(vehicle.ui_config, desc.ui_hide, False):
+        return False
+    return True
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: MyHondaPlusConfigEntry,
@@ -255,11 +282,13 @@ async def async_setup_entry(
         entities.extend(
             HondaSensor(vehicle.coordinator, desc, vin, name, fuel_type)
             for desc in SENSOR_DESCRIPTIONS
+            if _sensor_enabled(desc, vehicle)
         )
-        entities.extend(
-            HondaTripSensor(vehicle.trip_coordinator, desc, vin, name, fuel_type)
-            for desc in TRIP_SENSOR_DESCRIPTIONS
-        )
+        if vehicle.capabilities.journey_history:
+            entities.extend(
+                HondaTripSensor(vehicle.trip_coordinator, desc, vin, name, fuel_type)
+                for desc in TRIP_SENSOR_DESCRIPTIONS
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -17,7 +17,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
 from .data import MyHondaPlusConfigEntry
 from .entity import MyHondaPlusEntity
 
@@ -129,7 +128,13 @@ SENSOR_DESCRIPTIONS: list[HondaSensorDescription] = [
         key="charge_mode",
         translation_key="charge_mode",
         device_class=SensorDeviceClass.ENUM,
-        options=["unconfirmed", "100v_charging", "200v_charging", "fast_charging", "unknown"],
+        options=[
+            "unconfirmed",
+            "100v_charging",
+            "200v_charging",
+            "fast_charging",
+            "unknown",
+        ],
         icon="mdi:ev-station",
     ),
     HondaSensorDescription(
@@ -242,18 +247,19 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ sensors."""
-    coordinator = entry.runtime_data.coordinator
-    trip_coordinator = entry.runtime_data.trip_coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    entities: list[SensorEntity] = [
-        HondaSensor(coordinator, description, vin, vehicle_name)
-        for description in SENSOR_DESCRIPTIONS
-    ]
-    entities.extend(
-        HondaTripSensor(trip_coordinator, description, vin, vehicle_name)
-        for description in TRIP_SENSOR_DESCRIPTIONS
-    )
+    entities: list[SensorEntity] = []
+    for vehicle in entry.runtime_data.vehicles.values():
+        vin = vehicle.vin
+        name = vehicle.vehicle_name
+        fuel_type = vehicle.fuel_type
+        entities.extend(
+            HondaSensor(vehicle.coordinator, desc, vin, name, fuel_type)
+            for desc in SENSOR_DESCRIPTIONS
+        )
+        entities.extend(
+            HondaTripSensor(vehicle.trip_coordinator, desc, vin, name, fuel_type)
+            for desc in TRIP_SENSOR_DESCRIPTIONS
+        )
     async_add_entities(entities)
 
 
@@ -281,12 +287,18 @@ class HondaSensor(MyHondaPlusEntity, SensorEntity):
             return sum(1 for r in value if r.get("enabled"))
         if isinstance(value, list):
             return ", ".join(str(v) for v in value) if value else "none"
-        if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP and isinstance(value, str):
+        if (
+            self.entity_description.device_class == SensorDeviceClass.TIMESTAMP
+            and isinstance(value, str)
+        ):
             try:
                 return datetime.fromisoformat(value)
             except ValueError:
                 return None
-        if self.entity_description.device_class == SensorDeviceClass.ENUM and isinstance(value, str):
+        if (
+            self.entity_description.device_class == SensorDeviceClass.ENUM
+            and isinstance(value, str)
+        ):
             return value.replace(" ", "_")
         return value
 

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -292,11 +292,11 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-def _resolve_unit(data: dict, description: HondaSensorDescription) -> str | None:
+def _resolve_unit(data, description: HondaSensorDescription) -> str | None:
     """Resolve the unit of measurement from coordinator data."""
     if not description.dynamic_unit or not data:
         return description.native_unit_of_measurement
-    distance_unit = data.get("distance_unit", "km")
+    distance_unit = data.distance_unit if hasattr(data, "distance_unit") else "km"
     units = UNIT_MAP.get(distance_unit, UNIT_MAP["km"])
     return units.get(description.dynamic_unit)
 
@@ -309,7 +309,7 @@ class HondaSensor(MyHondaPlusEntity, SensorEntity):
 
     @property
     def native_value(self):
-        value = self.coordinator.data.get(self.entity_description.key)
+        value = getattr(self.coordinator.data, self.entity_description.key, None)
         if self.entity_description.key in SCHEDULE_KEYS:
             if not isinstance(value, list):
                 return 0
@@ -339,7 +339,7 @@ class HondaSensor(MyHondaPlusEntity, SensorEntity):
     def extra_state_attributes(self) -> dict | None:
         if self.entity_description.key not in SCHEDULE_KEYS:
             return None
-        value = self.coordinator.data.get(self.entity_description.key)
+        value = getattr(self.coordinator.data, self.entity_description.key, None)
         if not isinstance(value, list):
             return None
         return {"rules": value}

--- a/custom_components/myhondaplus/services.yaml
+++ b/custom_components/myhondaplus/services.yaml
@@ -3,12 +3,12 @@ set_charge_schedule:
   description: Update the vehicle's charge prohibition schedule. Pass an empty list to clear all rules.
 
   fields:
-    config_entry:
+    device:
       name: Vehicle
       description: Select the My Honda+ vehicle to control.
       required: true
       selector:
-        config_entry:
+        device:
           integration: myhondaplus
     rules:
       name: Schedule rules
@@ -26,12 +26,12 @@ climate_on:
   description: Apply the requested climate settings and then send the remote climate-start command to the vehicle.
 
   fields:
-    config_entry:
+    device:
       name: Vehicle
       description: Select the My Honda+ vehicle to control.
       required: true
       selector:
-        config_entry:
+        device:
           integration: myhondaplus
     temp:
       name: Temperature
@@ -71,12 +71,12 @@ set_climate_schedule:
   description: Update the vehicle's climate pre-conditioning schedule. Pass an empty list to clear all rules.
 
   fields:
-    config_entry:
+    device:
       name: Vehicle
       description: Select the My Honda+ vehicle to control.
       required: true
       selector:
-        config_entry:
+        device:
           integration: myhondaplus
     rules:
       name: Schedule rules

--- a/custom_components/myhondaplus/services.yaml
+++ b/custom_components/myhondaplus/services.yaml
@@ -49,8 +49,8 @@ climate_on:
       name: Duration
       description: Climate run time in minutes.
       required: false
-      default: 30
-      example: 30
+      default: "30"
+      example: "30"
       selector:
         select:
           options:

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       },
-      "select_vehicle": {
-        "title": "Select vehicle",
-        "description": "Multiple vehicles found on your account. Select which one to add.",
-        "data": {
-          "vin": "Vehicle"
-        },
-        "data_description": {
-          "vin": "Choose the vehicle from your My Honda+ account that should be added to Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Enter VIN",
         "description": "Could not auto-detect vehicles. Enter the VIN manually.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Unable to refresh location from vehicle"
     },
-    "config_entry_not_found": {
-      "message": "Failed to call service {service}. Config entry {entry_id} not found"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Failed to call service {service}. Config entry {entry_id} not loaded"
-    },
-    "config_entry_no_data": {
-      "message": "Failed to call service {service}. Config entry {entry_id} has no runtime data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/strings.json
+++ b/custom_components/myhondaplus/strings.json
@@ -87,6 +87,9 @@
     "send_command_failed": {
       "message": "Unable to send command to vehicle"
     },
+    "capability_not_supported": {
+      "message": "This vehicle does not support the requested feature"
+    },
     "refresh_location_failed": {
       "message": "Unable to refresh location from vehicle"
     },

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -1,5 +1,7 @@
 """Switch platform for My Honda+."""
 
+from dataclasses import replace
+
 from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
@@ -58,7 +60,7 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if climate is active."""
-        value = self.coordinator.data.get("climate_active")
+        value = self.coordinator.data.climate_active
         if isinstance(value, str) and value.lower() == "active":
             return True
         return to_bool(value)
@@ -70,9 +72,9 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
             self._vin,
         )
         if confirmed:
-            data = dict(self.coordinator.data)
-            data["climate_active"] = True
-            self.coordinator.async_set_updated_data(data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, climate_active=True)
+            )
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
@@ -81,9 +83,9 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
             self._vin,
         )
         if confirmed:
-            data = dict(self.coordinator.data)
-            data["climate_active"] = False
-            self.coordinator.async_set_updated_data(data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, climate_active=False)
+            )
 
 
 class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -105,11 +107,9 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if charging is active."""
-        value = self.coordinator.data.get("charge_status")
+        value = self.coordinator.data.charge_status
         if value is None:
             return None
-        if isinstance(value, bool):
-            return value
         if isinstance(value, str):
             return value.lower() in ("charging", "running")
         return bool(value)
@@ -121,9 +121,9 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
             self._vin,
         )
         if confirmed:
-            data = dict(self.coordinator.data)
-            data["charge_status"] = "charging"
-            self.coordinator.async_set_updated_data(data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, charge_status="charging")
+            )
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
@@ -132,9 +132,9 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
             self._vin,
         )
         if confirmed:
-            data = dict(self.coordinator.data)
-            data["charge_status"] = "not_charging"
-            self.coordinator.async_set_updated_data(data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, charge_status="not_charging")
+            )
 
 
 class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -157,7 +157,7 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if defrost is enabled."""
-        return bool(self.coordinator.data.get("climate_defrost", True))
+        return bool(self.coordinator.data.climate_defrost)
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable defrost."""
@@ -168,11 +168,11 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
         await self._set_defrost(False)
 
     async def _set_defrost(self, defrost: bool) -> None:
-        data = self.coordinator.data or {}
-        temp = data.get("climate_temp", "normal")
+        data = self.coordinator.data
+        temp = data.climate_temp
         if temp not in ("cooler", "normal", "hotter"):
             temp = "normal"
-        duration = data.get("climate_duration", 30)
+        duration = data.climate_duration
         if duration not in (10, 20, 30):
             duration = 30
         confirmed = await self.coordinator.async_send_command_and_wait(
@@ -183,9 +183,9 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
             defrost,
         )
         if confirmed:
-            new_data = dict(self.coordinator.data)
-            new_data["climate_defrost"] = defrost
-            self.coordinator.async_set_updated_data(new_data)
+            self.coordinator.async_set_updated_data(
+                replace(self.coordinator.data, climate_defrost=defrost)
+            )
 
 
 class HondaAutoRefreshSwitch(MyHondaPlusEntity, SwitchEntity):

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -9,8 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_VEHICLE_NAME, CONF_VIN
-from .data import MyHondaPlusConfigEntry
+from .data import MyHondaPlusConfigEntry, VehicleData
 from .entity import MyHondaPlusEntity, to_bool
 
 PARALLEL_UPDATES = 1
@@ -22,15 +21,21 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up My Honda+ switches."""
-    coordinator = entry.runtime_data.coordinator
-    vin = entry.data[CONF_VIN]
-    vehicle_name = entry.data.get(CONF_VEHICLE_NAME, "")
-    async_add_entities([
-        HondaClimateSwitch(coordinator, vin, vehicle_name),
-        HondaChargeSwitch(coordinator, vin, vehicle_name),
-        HondaDefrostSwitch(coordinator, vin, vehicle_name),
-        HondaAutoRefreshSwitch(coordinator, vin, vehicle_name, entry),
-    ])
+    entities = []
+    for vehicle in entry.runtime_data.vehicles.values():
+        c = vehicle.coordinator
+        vin = vehicle.vin
+        name = vehicle.vehicle_name
+        fuel_type = vehicle.fuel_type
+        entities.extend(
+            [
+                HondaClimateSwitch(c, vin, name, fuel_type),
+                HondaChargeSwitch(c, vin, name, fuel_type),
+                HondaDefrostSwitch(c, vin, name, fuel_type),
+                HondaAutoRefreshSwitch(c, vin, name, fuel_type, vehicle),
+            ]
+        )
+    async_add_entities(entities)
 
 
 class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
@@ -40,12 +45,14 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
     _attr_icon = "mdi:air-conditioner"
     _attr_translation_key = "climate"
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = SwitchEntityDescription(
             key="climate",
             translation_key="climate",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def is_on(self) -> bool | None:
@@ -58,7 +65,8 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Start climate pre-conditioning."""
         confirmed = await self.coordinator.async_send_command_and_wait(
-            self.coordinator.api.remote_climate_start, self._vin,
+            self.coordinator.api.remote_climate_start,
+            self._vin,
         )
         if confirmed:
             data = dict(self.coordinator.data)
@@ -68,7 +76,8 @@ class HondaClimateSwitch(MyHondaPlusEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         """Stop climate pre-conditioning."""
         confirmed = await self.coordinator.async_send_command_and_wait(
-            self.coordinator.api.remote_climate_stop, self._vin,
+            self.coordinator.api.remote_climate_stop,
+            self._vin,
         )
         if confirmed:
             data = dict(self.coordinator.data)
@@ -83,12 +92,14 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
     _attr_icon = "mdi:ev-station"
     _attr_translation_key = "charging"
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = SwitchEntityDescription(
             key="charging",
             translation_key="charging",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def is_on(self) -> bool | None:
@@ -105,7 +116,8 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Start charging."""
         confirmed = await self.coordinator.async_send_command_and_wait(
-            self.coordinator.api.remote_charge_start, self._vin,
+            self.coordinator.api.remote_charge_start,
+            self._vin,
         )
         if confirmed:
             data = dict(self.coordinator.data)
@@ -115,7 +127,8 @@ class HondaChargeSwitch(MyHondaPlusEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         """Stop charging."""
         confirmed = await self.coordinator.async_send_command_and_wait(
-            self.coordinator.api.remote_charge_stop, self._vin,
+            self.coordinator.api.remote_charge_stop,
+            self._vin,
         )
         if confirmed:
             data = dict(self.coordinator.data)
@@ -131,12 +144,14 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
     _attr_translation_key = "climate_defrost_setting"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str) -> None:
+    def __init__(
+        self, coordinator, vin: str, vehicle_name: str, fuel_type: str = ""
+    ) -> None:
         description = SwitchEntityDescription(
             key="climate_defrost_setting",
             translation_key="climate_defrost_setting",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
 
     @property
     def is_on(self) -> bool:
@@ -161,7 +176,10 @@ class HondaDefrostSwitch(MyHondaPlusEntity, SwitchEntity):
             duration = 30
         confirmed = await self.coordinator.async_send_command_and_wait(
             self.coordinator.api.set_climate_settings,
-            self._vin, temp, duration, defrost,
+            self._vin,
+            temp,
+            duration,
+            defrost,
         )
         if confirmed:
             new_data = dict(self.coordinator.data)
@@ -177,25 +195,32 @@ class HondaAutoRefreshSwitch(MyHondaPlusEntity, SwitchEntity):
     _attr_translation_key = "auto_refresh"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator, vin: str, vehicle_name: str, entry) -> None:
+    def __init__(
+        self,
+        coordinator,
+        vin: str,
+        vehicle_name: str,
+        fuel_type: str,
+        vehicle_data: VehicleData,
+    ) -> None:
         description = SwitchEntityDescription(
             key="auto_refresh",
             translation_key="auto_refresh",
         )
-        super().__init__(coordinator, description, vin, vehicle_name)
-        self._entry = entry
+        super().__init__(coordinator, description, vin, vehicle_name, fuel_type)
+        self._vehicle_data = vehicle_data
 
     @property
     def is_on(self) -> bool:
         """Return true if auto refresh is enabled."""
-        return self._entry.runtime_data.car_refresh_enabled
+        return self._vehicle_data.car_refresh_enabled
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable auto refresh."""
-        self._entry.runtime_data.car_refresh_enabled = True
+        self._vehicle_data.car_refresh_enabled = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Disable auto refresh."""
-        self._entry.runtime_data.car_refresh_enabled = False
+        self._vehicle_data.car_refresh_enabled = False
         self.async_write_ha_state()

--- a/custom_components/myhondaplus/switch.py
+++ b/custom_components/myhondaplus/switch.py
@@ -27,14 +27,15 @@ async def async_setup_entry(
         vin = vehicle.vin
         name = vehicle.vehicle_name
         fuel_type = vehicle.fuel_type
-        entities.extend(
-            [
-                HondaClimateSwitch(c, vin, name, fuel_type),
-                HondaChargeSwitch(c, vin, name, fuel_type),
-                HondaDefrostSwitch(c, vin, name, fuel_type),
-                HondaAutoRefreshSwitch(c, vin, name, fuel_type, vehicle),
-            ]
-        )
+        caps = vehicle.capabilities
+        ui = vehicle.ui_config
+        if caps.remote_climate:
+            entities.append(HondaClimateSwitch(c, vin, name, fuel_type))
+            if not ui.hide_climate_settings:
+                entities.append(HondaDefrostSwitch(c, vin, name, fuel_type))
+        if caps.remote_charge:
+            entities.append(HondaChargeSwitch(c, vin, name, fuel_type))
+        entities.append(HondaAutoRefreshSwitch(c, vin, name, fuel_type, vehicle))
     async_add_entities(entities)
 
 

--- a/custom_components/myhondaplus/translations/cs.json
+++ b/custom_components/myhondaplus/translations/cs.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Jak často Home Assistant požaduje GPS polohu z vozidla. Nastavte 0 pro vypnutí."
         }
       },
-      "select_vehicle": {
-        "title": "Výběr vozidla",
-        "description": "Ve vašem účtu bylo nalezeno více vozidel. Vyberte, které chcete přidat.",
-        "data": {
-          "vin": "Vozidlo"
-        },
-        "data_description": {
-          "vin": "Vyberte vozidlo z vašeho účtu My Honda+, které chcete přidat do Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Zadejte VIN",
         "description": "Automatická detekce vozidel se nezdařila. Zadejte VIN ručně.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Nepodařilo se aktualizovat polohu z vozidla"
     },
-    "config_entry_not_found": {
-      "message": "Nelze zavolat službu {service}. Konfigurační záznam {entry_id} nebyl nalezen"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Nelze zavolat službu {service}. Konfigurační záznam {entry_id} není načten"
-    },
-    "config_entry_no_data": {
-      "message": "Nelze zavolat službu {service}. Konfigurační záznam {entry_id} nemá data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/da.json
+++ b/custom_components/myhondaplus/translations/da.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Hvor ofte Home Assistant anmoder om GPS-position fra køretøjet. Sæt til 0 for at deaktivere."
         }
       },
-      "select_vehicle": {
-        "title": "Vælg køretøj",
-        "description": "Der blev fundet flere køretøjer på din konto. Vælg hvilket der skal tilføjes.",
-        "data": {
-          "vin": "Køretøj"
-        },
-        "data_description": {
-          "vin": "Vælg køretøjet fra din My Honda+ konto der skal tilføjes til Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Indtast VIN",
         "description": "Automatisk registrering af køretøjer mislykkedes. Indtast VIN manuelt.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Kunne ikke opdatere positionen fra køretøjet"
     },
-    "config_entry_not_found": {
-      "message": "Kan ikke kalde tjenesten {service}. Konfigurationspost {entry_id} ikke fundet"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Kan ikke kalde tjenesten {service}. Konfigurationspost {entry_id} ikke indlæst"
-    },
-    "config_entry_no_data": {
-      "message": "Kan ikke kalde tjenesten {service}. Konfigurationspost {entry_id} uden data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/de.json
+++ b/custom_components/myhondaplus/translations/de.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Wie oft Home Assistant die GPS-Position vom Fahrzeug abruft. Auf 0 setzen zum Deaktivieren."
         }
       },
-      "select_vehicle": {
-        "title": "Fahrzeug auswählen",
-        "description": "Es wurden mehrere Fahrzeuge in deinem Konto gefunden. Wähle aus, welches hinzugefügt werden soll.",
-        "data": {
-          "vin": "Fahrzeug"
-        },
-        "data_description": {
-          "vin": "Wähle das Fahrzeug aus deinem My Honda+ Konto, das zu Home Assistant hinzugefügt werden soll."
-        }
-      },
       "manual_vin": {
         "title": "VIN eingeben",
         "description": "Fahrzeuge konnten nicht automatisch erkannt werden. Bitte gib die VIN manuell ein.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Standort vom Fahrzeug konnte nicht aktualisiert werden"
     },
-    "config_entry_not_found": {
-      "message": "Dienst {service} konnte nicht aufgerufen werden. Konfigurationseintrag {entry_id} nicht gefunden"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Dienst {service} konnte nicht aufgerufen werden. Konfigurationseintrag {entry_id} nicht geladen"
-    },
-    "config_entry_no_data": {
-      "message": "Dienst {service} konnte nicht aufgerufen werden. Konfigurationseintrag {entry_id} ohne Daten"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/en.json
+++ b/custom_components/myhondaplus/translations/en.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "How often Home Assistant requests fresh GPS data from the vehicle. Set to 0 to disable."
         }
       },
-      "select_vehicle": {
-        "title": "Select vehicle",
-        "description": "Multiple vehicles found on your account. Select which one to add.",
-        "data": {
-          "vin": "Vehicle"
-        },
-        "data_description": {
-          "vin": "Choose the vehicle from your My Honda+ account that should be added to Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Enter VIN",
         "description": "Could not auto-detect vehicles. Enter the VIN manually.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Unable to refresh location from vehicle"
     },
-    "config_entry_not_found": {
-      "message": "Failed to call service {service}. Config entry {entry_id} not found"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Failed to call service {service}. Config entry {entry_id} not loaded"
-    },
-    "config_entry_no_data": {
-      "message": "Failed to call service {service}. Config entry {entry_id} has no runtime data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/es.json
+++ b/custom_components/myhondaplus/translations/es.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Frecuencia con la que Home Assistant solicita la posición GPS del vehículo. Establecer en 0 para desactivar."
         }
       },
-      "select_vehicle": {
-        "title": "Seleccionar vehículo",
-        "description": "Se encontraron varios vehículos en tu cuenta. Selecciona cuál añadir.",
-        "data": {
-          "vin": "Vehículo"
-        },
-        "data_description": {
-          "vin": "Elige el vehículo de tu cuenta My Honda+ para añadir a Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Introducir VIN",
         "description": "No se pudieron detectar los vehículos automáticamente. Introduce el VIN manualmente.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "No se pudo actualizar la ubicación del vehículo"
     },
-    "config_entry_not_found": {
-      "message": "No se pudo llamar al servicio {service}. Entrada de configuración {entry_id} no encontrada"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "No se pudo llamar al servicio {service}. Entrada de configuración {entry_id} no cargada"
-    },
-    "config_entry_no_data": {
-      "message": "No se pudo llamar al servicio {service}. Entrada de configuración {entry_id} sin datos"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/fr.json
+++ b/custom_components/myhondaplus/translations/fr.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Fréquence à laquelle Home Assistant demande la position GPS au véhicule. Mettre à 0 pour désactiver."
         }
       },
-      "select_vehicle": {
-        "title": "Sélectionner le véhicule",
-        "description": "Plusieurs véhicules ont été trouvés dans votre compte. Sélectionnez celui à ajouter.",
-        "data": {
-          "vin": "Véhicule"
-        },
-        "data_description": {
-          "vin": "Choisissez le véhicule de votre compte My Honda+ à ajouter à Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Entrer le VIN",
         "description": "Impossible de détecter automatiquement les véhicules. Veuillez entrer le VIN manuellement.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Impossible de mettre à jour la position du véhicule"
     },
-    "config_entry_not_found": {
-      "message": "Impossible d'appeler le service {service}. Entrée de configuration {entry_id} introuvable"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Impossible d'appeler le service {service}. Entrée de configuration {entry_id} non chargée"
-    },
-    "config_entry_no_data": {
-      "message": "Impossible d'appeler le service {service}. Entrée de configuration {entry_id} sans données"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/hu.json
+++ b/custom_components/myhondaplus/translations/hu.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Milyen gyakran kérje le a Home Assistant a GPS helyzetet a járműtől. Állítsd 0-ra a letiltáshoz."
         }
       },
-      "select_vehicle": {
-        "title": "Jármű kiválasztása",
-        "description": "Több jármű található a fiókodban. Válaszd ki, melyiket szeretnéd hozzáadni.",
-        "data": {
-          "vin": "Jármű"
-        },
-        "data_description": {
-          "vin": "Válaszd ki a My Honda+ fiókodból a Home Assistant-hoz hozzáadni kívánt járművet."
-        }
-      },
       "manual_vin": {
         "title": "VIN megadása",
         "description": "A járművek automatikus felismerése nem sikerült. Add meg a VIN-t kézzel.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Nem sikerült frissíteni a helyzetet a járműtől"
     },
-    "config_entry_not_found": {
-      "message": "Nem sikerült meghívni a(z) {service} szolgáltatást. A(z) {entry_id} konfigurációs bejegyzés nem található"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Nem sikerült meghívni a(z) {service} szolgáltatást. A(z) {entry_id} konfigurációs bejegyzés nincs betöltve"
-    },
-    "config_entry_no_data": {
-      "message": "Nem sikerült meghívni a(z) {service} szolgáltatást. A(z) {entry_id} konfigurációs bejegyzésnek nincsenek adatai"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/it.json
+++ b/custom_components/myhondaplus/translations/it.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Ogni quanto Home Assistant richiede la posizione GPS dal veicolo. Imposta 0 per disabilitare."
         }
       },
-      "select_vehicle": {
-        "title": "Seleziona veicolo",
-        "description": "Sono stati trovati più veicoli nel tuo account. Seleziona quale aggiungere.",
-        "data": {
-          "vin": "Veicolo"
-        },
-        "data_description": {
-          "vin": "Scegli il veicolo dal tuo account My Honda+ da aggiungere a Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Inserisci VIN",
         "description": "Impossibile rilevare automaticamente i veicoli. Inserisci il VIN manualmente.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Impossibile aggiornare la posizione dal veicolo"
     },
-    "config_entry_not_found": {
-      "message": "Impossibile chiamare il servizio {service}. Voce di configurazione {entry_id} non trovata"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Impossibile chiamare il servizio {service}. Voce di configurazione {entry_id} non caricata"
-    },
-    "config_entry_no_data": {
-      "message": "Impossibile chiamare il servizio {service}. Voce di configurazione {entry_id} senza dati"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/nl.json
+++ b/custom_components/myhondaplus/translations/nl.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Hoe vaak Home Assistant de GPS-locatie van het voertuig opvraagt. Stel in op 0 om uit te schakelen."
         }
       },
-      "select_vehicle": {
-        "title": "Selecteer voertuig",
-        "description": "Er zijn meerdere voertuigen gevonden in je account. Selecteer welke je wilt toevoegen.",
-        "data": {
-          "vin": "Voertuig"
-        },
-        "data_description": {
-          "vin": "Kies het voertuig uit je My Honda+ account om toe te voegen aan Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Voer VIN in",
         "description": "Automatische detectie van voertuigen is mislukt. Voer het VIN handmatig in.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Kan de locatie van het voertuig niet vernieuwen"
     },
-    "config_entry_not_found": {
-      "message": "Kan service {service} niet aanroepen. Configuratie-item {entry_id} niet gevonden"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Kan service {service} niet aanroepen. Configuratie-item {entry_id} niet geladen"
-    },
-    "config_entry_no_data": {
-      "message": "Kan service {service} niet aanroepen. Configuratie-item {entry_id} zonder gegevens"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/no.json
+++ b/custom_components/myhondaplus/translations/no.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Hvor ofte Home Assistant henter GPS-posisjonen fra kjøretøyet. Sett til 0 for å deaktivere."
         }
       },
-      "select_vehicle": {
-        "title": "Velg kjøretøy",
-        "description": "Flere kjøretøy ble funnet på kontoen din. Velg hvilket du vil legge til.",
-        "data": {
-          "vin": "Kjøretøy"
-        },
-        "data_description": {
-          "vin": "Velg kjøretøyet fra din My Honda+-konto som du vil legge til i Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Skriv inn VIN",
         "description": "Kunne ikke oppdage kjøretøy automatisk. Skriv inn VIN manuelt.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Kunne ikke oppdatere posisjonen fra kjøretøyet"
     },
-    "config_entry_not_found": {
-      "message": "Kunne ikke kalle tjenesten {service}. Konfigurasjonsoppføring {entry_id} ble ikke funnet"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Kunne ikke kalle tjenesten {service}. Konfigurasjonsoppføring {entry_id} er ikke lastet"
-    },
-    "config_entry_no_data": {
-      "message": "Kunne ikke kalle tjenesten {service}. Konfigurasjonsoppføring {entry_id} har ingen data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/pl.json
+++ b/custom_components/myhondaplus/translations/pl.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Jak często Home Assistant pobiera pozycję GPS z pojazdu. Ustaw 0, aby wyłączyć."
         }
       },
-      "select_vehicle": {
-        "title": "Wybierz pojazd",
-        "description": "Na Twoim koncie znaleziono wiele pojazdów. Wybierz, który chcesz dodać.",
-        "data": {
-          "vin": "Pojazd"
-        },
-        "data_description": {
-          "vin": "Wybierz pojazd z konta My Honda+, który chcesz dodać do Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Wprowadź VIN",
         "description": "Nie udało się automatycznie wykryć pojazdów. Wprowadź VIN ręcznie.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Nie udało się odświeżyć lokalizacji z pojazdu"
     },
-    "config_entry_not_found": {
-      "message": "Nie można wywołać usługi {service}. Wpis konfiguracji {entry_id} nie został znaleziony"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Nie można wywołać usługi {service}. Wpis konfiguracji {entry_id} nie jest załadowany"
-    },
-    "config_entry_no_data": {
-      "message": "Nie można wywołać usługi {service}. Wpis konfiguracji {entry_id} nie ma danych"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/sk.json
+++ b/custom_components/myhondaplus/translations/sk.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Ako často Home Assistant požaduje GPS polohu z vozidla. Nastavte 0 pre vypnutie."
         }
       },
-      "select_vehicle": {
-        "title": "Výber vozidla",
-        "description": "Na vašom účte bolo nájdených viac vozidiel. Vyberte, ktoré chcete pridať.",
-        "data": {
-          "vin": "Vozidlo"
-        },
-        "data_description": {
-          "vin": "Vyberte vozidlo z vášho účtu My Honda+, ktoré chcete pridať do Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Zadajte VIN",
         "description": "Automatická detekcia vozidiel sa nepodarila. Zadajte VIN ručne.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Nepodarilo sa aktualizovať polohu z vozidla"
     },
-    "config_entry_not_found": {
-      "message": "Nie je možné zavolať službu {service}. Konfiguračný záznam {entry_id} nebol nájdený"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Nie je možné zavolať službu {service}. Konfiguračný záznam {entry_id} nie je načítaný"
-    },
-    "config_entry_no_data": {
-      "message": "Nie je možné zavolať službu {service}. Konfiguračný záznam {entry_id} nemá dáta"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/custom_components/myhondaplus/translations/sv.json
+++ b/custom_components/myhondaplus/translations/sv.json
@@ -19,16 +19,6 @@
           "location_refresh_interval": "Hur ofta Home Assistant begär GPS-position från fordonet. Sätt till 0 för att inaktivera."
         }
       },
-      "select_vehicle": {
-        "title": "Välj fordon",
-        "description": "Flera fordon hittades i ditt konto. Välj vilket som ska läggas till.",
-        "data": {
-          "vin": "Fordon"
-        },
-        "data_description": {
-          "vin": "Välj fordonet från ditt My Honda+ konto att lägga till i Home Assistant."
-        }
-      },
       "manual_vin": {
         "title": "Ange VIN",
         "description": "Automatisk identifiering av fordon misslyckades. Ange VIN manuellt.",
@@ -100,14 +90,11 @@
     "refresh_location_failed": {
       "message": "Kunde inte uppdatera positionen från fordonet"
     },
-    "config_entry_not_found": {
-      "message": "Kan inte anropa tjänsten {service}. Konfigurationspost {entry_id} hittades inte"
+    "device_required": {
+      "message": "Select a vehicle to control."
     },
-    "config_entry_not_loaded": {
-      "message": "Kan inte anropa tjänsten {service}. Konfigurationspost {entry_id} inte laddad"
-    },
-    "config_entry_no_data": {
-      "message": "Kan inte anropa tjänsten {service}. Konfigurationspost {entry_id} utan data"
+    "device_not_found": {
+      "message": "Vehicle not found or not loaded."
     }
   },
   "entity": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,17 +17,36 @@ from custom_components.myhondaplus.const import (
     CONF_SCAN_INTERVAL,
     CONF_USER_ID,
     CONF_VEHICLE_NAME,
+    CONF_VEHICLES,
     CONF_VIN,
     DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_LOCATION_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+from custom_components.myhondaplus.data import MyHondaPlusData, VehicleData
 
 MOCK_VIN = "ZHWGE11S00LA00001"
 MOCK_VEHICLE_NAME = "Honda e Test"
 
 MOCK_ENTRY_DATA = {
+    "email": "test@example.com",
+    CONF_ACCESS_TOKEN: "fake-access-token",
+    CONF_REFRESH_TOKEN: "fake-refresh-token",
+    CONF_USER_ID: "fake-user-id",
+    CONF_PERSONAL_ID: "fake-personal-id",
+    CONF_VEHICLES: [
+        {
+            CONF_VIN: MOCK_VIN,
+            CONF_VEHICLE_NAME: MOCK_VEHICLE_NAME,
+            CONF_FUEL_TYPE: "E",
+        },
+    ],
+}
+
+# Legacy v2 entry data (for migration tests)
+MOCK_V2_ENTRY_DATA = {
+    "email": "test@example.com",
     CONF_VIN: MOCK_VIN,
     CONF_VEHICLE_NAME: MOCK_VEHICLE_NAME,
     CONF_ACCESS_TOKEN: "fake-access-token",
@@ -80,14 +99,27 @@ MOCK_DASHBOARD_DATA = {
     "climate_duration": 30,
     "climate_defrost": True,
     "charge_schedule": [
-        {"enabled": True, "days": ["mon", "tue", "wed", "thu", "fri"],
-         "location": "home", "start_time": "22:00", "end_time": "06:00"},
-        {"enabled": False, "days": [], "location": "home",
-         "start_time": "00:00", "end_time": "00:00"},
+        {
+            "enabled": True,
+            "days": ["mon", "tue", "wed", "thu", "fri"],
+            "location": "home",
+            "start_time": "22:00",
+            "end_time": "06:00",
+        },
+        {
+            "enabled": False,
+            "days": [],
+            "location": "home",
+            "start_time": "00:00",
+            "end_time": "00:00",
+        },
     ],
     "climate_schedule": [
-        {"enabled": True, "days": ["mon", "tue", "wed", "thu", "fri"],
-         "start_time": "07:00"},
+        {
+            "enabled": True,
+            "days": ["mon", "tue", "wed", "thu", "fri"],
+            "start_time": "07:00",
+        },
         {"enabled": False, "days": [], "start_time": "00:00"},
     ],
 }
@@ -116,7 +148,12 @@ def mock_api():
     api.get_dashboard_cached.return_value = {}
     api.get_all_trips.return_value = []
     api.get_vehicles.return_value = [
-        {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "plate": "AB123CD", "fuel_type": "E"},
+        {
+            "vin": MOCK_VIN,
+            "name": MOCK_VEHICLE_NAME,
+            "plate": "AB123CD",
+            "fuel_type": "E",
+        },
     ]
     api.remote_horn_lights.return_value = "ok"
     api.remote_climate_start.return_value = "ok"
@@ -139,7 +176,8 @@ def mock_config_entry():
     entry.options = dict(MOCK_ENTRY_OPTIONS)
     entry.entry_id = "test_entry_id"
     entry.domain = DOMAIN
-    entry.title = MOCK_VEHICLE_NAME
+    entry.title = "My Honda+ (test@example.com)"
+    entry.version = 3
     return entry
 
 
@@ -150,6 +188,7 @@ def mock_coordinator(mock_api, mock_config_entry):
     coordinator.data = dict(MOCK_DASHBOARD_DATA)
     coordinator.api = mock_api
     coordinator.entry = mock_config_entry
+    coordinator.vin = MOCK_VIN
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_send_command = AsyncMock()
     coordinator.async_send_command_and_wait = AsyncMock(return_value=True)
@@ -159,14 +198,34 @@ def mock_coordinator(mock_api, mock_config_entry):
 
 
 @pytest.fixture
-def mock_trip_coordinator():
+def mock_trip_coordinator(mock_config_entry):
     """Return a mocked trip coordinator with realistic data."""
     coordinator = MagicMock()
     coordinator.data = dict(MOCK_TRIP_DATA)
-    coordinator.entry = MagicMock()
-    coordinator.entry.data = dict(MOCK_ENTRY_DATA)
+    coordinator.entry = mock_config_entry
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
+
+
+@pytest.fixture
+def mock_vehicle_data(mock_coordinator, mock_trip_coordinator):
+    """Return a VehicleData instance for the test vehicle."""
+    return VehicleData(
+        coordinator=mock_coordinator,
+        trip_coordinator=mock_trip_coordinator,
+        vin=MOCK_VIN,
+        vehicle_name=MOCK_VEHICLE_NAME,
+        fuel_type="E",
+    )
+
+
+@pytest.fixture
+def mock_runtime_data(mock_vehicle_data, mock_api):
+    """Return a MyHondaPlusData instance."""
+    return MyHondaPlusData(
+        vehicles={MOCK_VIN: mock_vehicle_data},
+        api=mock_api,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,6 +25,7 @@ from custom_components.myhondaplus.const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+from custom_components.myhondaplus.coordinator import DashboardData
 from custom_components.myhondaplus.data import MyHondaPlusData, VehicleData
 
 MOCK_VIN = "ZHWGE11S00LA00001"
@@ -62,43 +64,43 @@ MOCK_ENTRY_OPTIONS = {
     CONF_LOCATION_REFRESH_INTERVAL: DEFAULT_LOCATION_REFRESH_INTERVAL,
 }
 
-MOCK_DASHBOARD_DATA = {
-    "battery_level": 75,
-    "range_climate_on": 150,
-    "range_climate_off": 180,
-    "total_range": 150,
-    "distance_unit": "km",
-    "speed_unit": "km/h",
-    "temp_unit": "c",
-    "charge_status": "not_charging",
-    "plug_status": "connected",
-    "home_away": "home",
-    "charge_limit_home": 90,
-    "charge_limit_away": 100,
-    "climate_active": False,
-    "cabin_temp": 22,
-    "interior_temp": 21,
-    "odometer": 12345,
-    "latitude": "45.0",
-    "longitude": "9.0",
-    "timestamp": "2026-03-24T10:00:00Z",
-    "doors_locked": True,
-    "all_doors_closed": True,
-    "all_windows_closed": True,
-    "ignition": "off",
-    "speed": 0,
-    "charge_mode": "normal",
-    "time_to_charge": 0,
-    "hood_open": False,
-    "trunk_open": False,
-    "lights_on": False,
-    "headlights": "off",
-    "parking_lights": "off",
-    "warning_lamps": [],
-    "climate_temp": "normal",
-    "climate_duration": 30,
-    "climate_defrost": True,
-    "charge_schedule": [
+MOCK_DASHBOARD_DATA = DashboardData(
+    battery_level=75,
+    range_climate_on=150,
+    range_climate_off=180,
+    total_range=150,
+    distance_unit="km",
+    speed_unit="km/h",
+    temp_unit="c",
+    charge_status="not_charging",
+    plug_status="connected",
+    home_away="home",
+    charge_limit_home=90,
+    charge_limit_away=100,
+    climate_active=False,
+    cabin_temp=22,
+    interior_temp=21,
+    odometer=12345,
+    latitude="45.0",
+    longitude="9.0",
+    timestamp="2026-03-24T10:00:00Z",
+    doors_locked=True,
+    all_doors_closed=True,
+    all_windows_closed=True,
+    ignition="off",
+    speed=0,
+    charge_mode="normal",
+    time_to_charge=0,
+    hood_open=False,
+    trunk_open=False,
+    lights_on=False,
+    headlights="off",
+    parking_lights="off",
+    warning_lamps=[],
+    climate_temp="normal",
+    climate_duration=30,
+    climate_defrost=True,
+    charge_schedule=[
         {
             "enabled": True,
             "days": ["mon", "tue", "wed", "thu", "fri"],
@@ -114,7 +116,7 @@ MOCK_DASHBOARD_DATA = {
             "end_time": "00:00",
         },
     ],
-    "climate_schedule": [
+    climate_schedule=[
         {
             "enabled": True,
             "days": ["mon", "tue", "wed", "thu", "fri"],
@@ -122,7 +124,7 @@ MOCK_DASHBOARD_DATA = {
         },
         {"enabled": False, "days": [], "start_time": "00:00"},
     ],
-}
+)
 
 MOCK_TRIP_DATA = {
     "trips": 15,
@@ -185,7 +187,7 @@ def mock_config_entry():
 def mock_coordinator(mock_api, mock_config_entry):
     """Return a mocked coordinator with realistic data."""
     coordinator = MagicMock()
-    coordinator.data = dict(MOCK_DASHBOARD_DATA)
+    coordinator.data = replace(MOCK_DASHBOARD_DATA)
     coordinator.api = mock_api
     coordinator.entry = mock_config_entry
     coordinator.vin = MOCK_VIN

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -23,12 +23,12 @@ def make_binary_sensor(coordinator, key):
 class TestDoorsBinarySensor:
     def test_is_on_when_doors_open(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "doors_open")
-        mock_coordinator.data["all_doors_closed"] = False
+        mock_coordinator.data.all_doors_closed = False
         assert sensor.is_on is True
 
     def test_is_off_when_doors_closed(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "doors_open")
-        mock_coordinator.data["all_doors_closed"] = True
+        mock_coordinator.data.all_doors_closed = True
         assert sensor.is_on is False
 
     def test_device_class(self, mock_coordinator):
@@ -37,19 +37,19 @@ class TestDoorsBinarySensor:
 
     def test_none_when_missing(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "doors_open")
-        mock_coordinator.data.pop("all_doors_closed", None)
+        mock_coordinator.data.all_doors_closed = None
         assert sensor.is_on is None
 
 
 class TestWindowsBinarySensor:
     def test_is_on_when_windows_open(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "windows_open")
-        mock_coordinator.data["all_windows_closed"] = False
+        mock_coordinator.data.all_windows_closed = False
         assert sensor.is_on is True
 
     def test_is_off_when_windows_closed(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "windows_open")
-        mock_coordinator.data["all_windows_closed"] = True
+        mock_coordinator.data.all_windows_closed = True
         assert sensor.is_on is False
 
     def test_device_class(self, mock_coordinator):
@@ -60,12 +60,12 @@ class TestWindowsBinarySensor:
 class TestHoodBinarySensor:
     def test_is_on_when_hood_open(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "hood")
-        mock_coordinator.data["hood_open"] = True
+        mock_coordinator.data.hood_open = True
         assert sensor.is_on is True
 
     def test_is_off_when_hood_closed(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "hood")
-        mock_coordinator.data["hood_open"] = False
+        mock_coordinator.data.hood_open = False
         assert sensor.is_on is False
 
     def test_device_class(self, mock_coordinator):
@@ -76,24 +76,24 @@ class TestHoodBinarySensor:
 class TestTrunkBinarySensor:
     def test_is_on_when_trunk_open(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "trunk")
-        mock_coordinator.data["trunk_open"] = True
+        mock_coordinator.data.trunk_open = True
         assert sensor.is_on is True
 
     def test_is_off_when_trunk_closed(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "trunk")
-        mock_coordinator.data["trunk_open"] = False
+        mock_coordinator.data.trunk_open = False
         assert sensor.is_on is False
 
 
 class TestLightsBinarySensor:
     def test_is_on_when_lights_on(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "lights")
-        mock_coordinator.data["lights_on"] = True
+        mock_coordinator.data.lights_on = True
         assert sensor.is_on is True
 
     def test_is_off_when_lights_off(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "lights")
-        mock_coordinator.data["lights_on"] = False
+        mock_coordinator.data.lights_on = False
         assert sensor.is_on is False
 
     def test_device_class(self, mock_coordinator):
@@ -106,20 +106,20 @@ class TestStringCoercion:
 
     def test_string_true(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "hood")
-        mock_coordinator.data["hood_open"] = "true"
+        mock_coordinator.data.hood_open = "true"
         assert sensor.is_on is True
 
     def test_string_false(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "hood")
-        mock_coordinator.data["hood_open"] = "false"
+        mock_coordinator.data.hood_open = "false"
         assert sensor.is_on is False
 
     def test_inverted_string_true(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "doors_open")
-        mock_coordinator.data["all_doors_closed"] = "true"
+        mock_coordinator.data.all_doors_closed = "true"
         assert sensor.is_on is False  # inverted: closed=true means NOT open
 
     def test_inverted_string_false(self, mock_coordinator):
         sensor = make_binary_sensor(mock_coordinator, "doors_open")
-        mock_coordinator.data["all_doors_closed"] = "false"
+        mock_coordinator.data.all_doors_closed = "false"
         assert sensor.is_on is True  # inverted: closed=false means open

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -23,7 +23,8 @@ class TestHondaButton:
         button = make_button(mock_coordinator, "horn_lights")
         await button.async_press()
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            mock_coordinator.api.remote_horn_lights, MOCK_VIN,
+            mock_coordinator.api.remote_horn_lights,
+            MOCK_VIN,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,19 +25,43 @@ from custom_components.myhondaplus.const import (
 from .conftest import MOCK_VEHICLE_NAME, MOCK_VIN
 
 MOCK_TOKENS = {"access_token": "fake-access", "refresh_token": "fake-refresh"}
-MOCK_VEHICLES = [
-    {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "plate": "AB123CD", "fuel_type": "E"},
-]
-MOCK_VEHICLES_MULTI = [
-    {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "plate": "AB123CD", "fuel_type": "E"},
-    {
-        "vin": "ZHWGE11S00LA00002",
-        "name": "Honda e:Ny1",
-        "plate": "EF456GH",
-        "fuel_type": "E",
-    },
-]
-MOCK_USER_INFO = {"personalId": "12345"}
+MOCK_USER_INFO = {
+    "personalId": "12345",
+    "vehiclesInfo": [
+        {
+            "vin": MOCK_VIN,
+            "vehicleNickName": MOCK_VEHICLE_NAME,
+            "vehicleRegNumber": "AB123CD",
+            "fuelType": "E",
+            "vehicleUIConfiguration": {"friendlyModelName": "Honda e"},
+            "grade": "E ADVANCE",
+            "modelYear": 2020,
+        },
+    ],
+}
+MOCK_USER_INFO_MULTI = {
+    "personalId": "12345",
+    "vehiclesInfo": [
+        {
+            "vin": MOCK_VIN,
+            "vehicleNickName": MOCK_VEHICLE_NAME,
+            "vehicleRegNumber": "AB123CD",
+            "fuelType": "E",
+            "vehicleUIConfiguration": {"friendlyModelName": "Honda e"},
+            "grade": "E ADVANCE",
+            "modelYear": 2020,
+        },
+        {
+            "vin": "ZHWGE11S00LA00002",
+            "vehicleNickName": "Honda e:Ny1",
+            "vehicleRegNumber": "EF456GH",
+            "fuelType": "E",
+            "vehicleUIConfiguration": {"friendlyModelName": "Honda e:Ny1"},
+            "grade": "E ADVANCE",
+            "modelYear": 2024,
+        },
+    ],
+}
 
 
 @pytest.fixture
@@ -67,8 +91,7 @@ class TestAsyncStepUser:
         """Login succeeds, one vehicle found → creates entry with vehicles list."""
         flow.hass.async_add_executor_job.side_effect = [
             MOCK_TOKENS,  # login
-            MOCK_VEHICLES,  # get_vehicles
-            MOCK_USER_INFO,  # get_user_info
+            MOCK_USER_INFO,  # get_user_info (vehicles + personalId)
         ]
 
         with (
@@ -116,8 +139,7 @@ class TestAsyncStepUser:
         """Login succeeds, multiple vehicles → creates entry with all vehicles."""
         flow.hass.async_add_executor_job.side_effect = [
             MOCK_TOKENS,  # login
-            MOCK_VEHICLES_MULTI,  # get_vehicles
-            MOCK_USER_INFO,  # get_user_info
+            MOCK_USER_INFO_MULTI,  # get_user_info
         ]
 
         with (
@@ -333,7 +355,6 @@ class TestAsyncStepVerify:
             flow.hass.async_add_executor_job.side_effect = [
                 None,  # verify_magic_link
                 MOCK_TOKENS,  # login
-                MOCK_VEHICLES,  # get_vehicles
                 MOCK_USER_INFO,  # get_user_info
             ]
 
@@ -521,7 +542,7 @@ class TestReauthFlow:
             mock_api_cls.return_value = mock_api
             reauth_flow.hass.async_add_executor_job.side_effect = [
                 MOCK_TOKENS,  # login
-                MOCK_VEHICLES,  # get_vehicles (for reconciliation)
+                MOCK_USER_INFO,  # get_user_info (for reconciliation)
             ]
 
             await reauth_flow.async_step_reauth_confirm(
@@ -700,7 +721,7 @@ class TestFetchVehiclesAndCreateEntry:
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
             mock_api_cls.return_value = mock_api
-            flow.hass.async_add_executor_job.side_effect = [MOCK_VEHICLES]
+            flow.hass.async_add_executor_job.side_effect = [MOCK_USER_INFO]
 
             result = await flow._fetch_vehicles_and_continue()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,12 +8,15 @@ from pymyhondaplus.api import HondaAuthError
 from custom_components.myhondaplus.config_flow import (
     MyHondaPlusConfigFlow,
     MyHondaPlusOptionsFlow,
+    _reconcile_vehicles,
 )
 from custom_components.myhondaplus.const import (
     CONF_CAR_REFRESH_INTERVAL,
+    CONF_FUEL_TYPE,
     CONF_LOCATION_REFRESH_INTERVAL,
     CONF_SCAN_INTERVAL,
     CONF_VEHICLE_NAME,
+    CONF_VEHICLES,
     CONF_VIN,
     DEFAULT_CAR_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
@@ -27,7 +30,12 @@ MOCK_VEHICLES = [
 ]
 MOCK_VEHICLES_MULTI = [
     {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "plate": "AB123CD", "fuel_type": "E"},
-    {"vin": "ZHWGE11S00LA00002", "name": "Honda e:Ny1", "plate": "EF456GH", "fuel_type": "E"},
+    {
+        "vin": "ZHWGE11S00LA00002",
+        "name": "Honda e:Ny1",
+        "plate": "EF456GH",
+        "fuel_type": "E",
+    },
 ]
 MOCK_USER_INFO = {"personalId": "12345"}
 
@@ -56,52 +64,107 @@ class TestAsyncStepUser:
 
     @pytest.mark.asyncio
     async def test_happy_path_single_vehicle(self, flow):
-        """Login succeeds, one vehicle found → creates entry."""
+        """Login succeeds, one vehicle found → creates entry with vehicles list."""
         flow.hass.async_add_executor_job.side_effect = [
             MOCK_TOKENS,  # login
             MOCK_VEHICLES,  # get_vehicles
             MOCK_USER_INFO,  # get_user_info
         ]
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
             mock_api_cls.return_value = mock_api
 
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass123",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-                "location_refresh_interval": 1800,
-            })
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass123",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                    "location_refresh_interval": 1800,
+                }
+            )
 
         flow.async_create_entry.assert_called_once()
         entry_kwargs = flow.async_create_entry.call_args[1]
         entry_data = entry_kwargs["data"]
         entry_options = entry_kwargs["options"]
-        assert entry_data[CONF_VIN] == MOCK_VIN
-        assert entry_data[CONF_VEHICLE_NAME] == MOCK_VEHICLE_NAME
+        # Vehicles stored as list
+        vehicles = entry_data[CONF_VEHICLES]
+        assert len(vehicles) == 1
+        assert vehicles[0][CONF_VIN] == MOCK_VIN
+        assert vehicles[0][CONF_VEHICLE_NAME] == MOCK_VEHICLE_NAME
+        # No top-level VIN
+        assert CONF_VIN not in entry_data
         assert CONF_SCAN_INTERVAL not in entry_data
         assert entry_options[CONF_SCAN_INTERVAL] == 600
         assert entry_options[CONF_LOCATION_REFRESH_INTERVAL] == 1800
+        # Title is email-based
+        assert "test@test.com" in entry_kwargs["title"]
+
+    @pytest.mark.asyncio
+    async def test_happy_path_multi_vehicle(self, flow):
+        """Login succeeds, multiple vehicles → creates entry with all vehicles."""
+        flow.hass.async_add_executor_job.side_effect = [
+            MOCK_TOKENS,  # login
+            MOCK_VEHICLES_MULTI,  # get_vehicles
+            MOCK_USER_INFO,  # get_user_info
+        ]
+
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
+            mock_auth_cls.return_value = MagicMock()
+            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
+            mock_api_cls.return_value = MagicMock()
+
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass123",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                    "location_refresh_interval": 1800,
+                }
+            )
+
+        flow.async_create_entry.assert_called_once()
+        vehicles = flow.async_create_entry.call_args[1]["data"][CONF_VEHICLES]
+        assert len(vehicles) == 2
+        vins = {v[CONF_VIN] for v in vehicles}
+        assert vins == {MOCK_VIN, "ZHWGE11S00LA00002"}
 
     @pytest.mark.asyncio
     async def test_invalid_credentials(self, flow):
         """Login with bad credentials shows error."""
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            flow.hass.async_add_executor_job.side_effect = HondaAuthError(401, "invalid-credentials")
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "wrong",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                401, "invalid-credentials"
+            )
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "wrong",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
         flow.async_show_form.assert_called()
         errors = flow.async_show_form.call_args[1]["errors"]
@@ -110,15 +173,21 @@ class TestAsyncStepUser:
     @pytest.mark.asyncio
     async def test_locked_account(self, flow):
         """Locked account shows error."""
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            flow.hass.async_add_executor_job.side_effect = HondaAuthError(401, "locked-account")
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                401, "locked-account"
+            )
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
         errors = flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "account_locked"
@@ -126,32 +195,39 @@ class TestAsyncStepUser:
     @pytest.mark.asyncio
     async def test_device_not_registered_goes_to_verify(self, flow):
         """Device-authenticator-not-registered triggers verification flow."""
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
 
-            # First call: login fails with device-authenticator-not-registered
-            # Second call: reset_device_authenticator succeeds
             flow.hass.async_add_executor_job.side_effect = [
                 HondaAuthError(401, "device-authenticator-not-registered"),
                 None,  # reset_device_authenticator
             ]
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
-        # Should show the verify form
         flow.async_show_form.assert_called()
         assert flow.async_show_form.call_args[1]["step_id"] == "verify"
 
     @pytest.mark.asyncio
     async def test_device_reset_failure_shows_cannot_connect(self, flow):
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
 
@@ -159,27 +235,35 @@ class TestAsyncStepUser:
                 HondaAuthError(401, "device-authenticator-not-registered"),
                 HondaAuthError(401, "reset failed"),
             ]
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
         errors = flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
 
     @pytest.mark.asyncio
     async def test_unknown_honda_auth_error_shows_cannot_connect(self, flow):
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            flow.hass.async_add_executor_job.side_effect = HondaAuthError(500, "something-else")
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                500, "something-else"
+            )
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
         errors = flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
@@ -187,15 +271,19 @@ class TestAsyncStepUser:
     @pytest.mark.asyncio
     async def test_generic_exception(self, flow):
         """Unexpected exception shows cannot_connect."""
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
             flow.hass.async_add_executor_job.side_effect = Exception("unexpected")
-            await flow.async_step_user({
-                "email": "test@test.com",
-                "password": "pass",
-                "scan_interval": 600,
-                "car_refresh_interval": 43200,
-            })
+            await flow.async_step_user(
+                {
+                    "email": "test@test.com",
+                    "password": "pass",
+                    "scan_interval": 600,
+                    "car_refresh_interval": 43200,
+                }
+            )
 
         errors = flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
@@ -211,7 +299,9 @@ class TestAsyncStepVerify:
     @pytest.mark.asyncio
     async def test_invalid_link(self, flow):
         """Invalid verification link shows error."""
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with patch(
+            "custom_components.myhondaplus.config_flow.HondaAuth"
+        ) as mock_auth_cls:
             mock_auth_cls.parse_verify_link_key.return_value = (None, None)
             await flow.async_step_verify({"verification_link": "bad-link"})
 
@@ -229,8 +319,12 @@ class TestAsyncStepVerify:
         flow._scan_interval = DEFAULT_SCAN_INTERVAL
         flow._car_refresh_interval = DEFAULT_CAR_REFRESH_INTERVAL
 
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+        with (
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth_cls.parse_verify_link_key.return_value = ("key123", "link_type")
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
@@ -243,7 +337,9 @@ class TestAsyncStepVerify:
                 MOCK_USER_INFO,  # get_user_info
             ]
 
-            await flow.async_step_verify({"verification_link": "https://honda.com/verify?key=abc"})
+            await flow.async_step_verify(
+                {"verification_link": "https://honda.com/verify?key=abc"}
+            )
 
         flow.async_create_entry.assert_called_once()
 
@@ -253,64 +349,21 @@ class TestAsyncStepVerify:
         flow._password = "pass"
         flow._auth = MagicMock()
 
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with patch(
+            "custom_components.myhondaplus.config_flow.HondaAuth"
+        ) as mock_auth_cls:
             mock_auth_cls.parse_verify_link_key.return_value = ("key123", "link_type")
             flow.hass.async_add_executor_job.side_effect = [
                 None,
                 HondaAuthError(401, "invalid-credentials"),
             ]
 
-            await flow.async_step_verify({"verification_link": "https://honda.com/verify?key=abc"})
+            await flow.async_step_verify(
+                {"verification_link": "https://honda.com/verify?key=abc"}
+            )
 
         errors = flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "verification_failed"
-
-
-class TestAsyncStepSelectVehicle:
-    @pytest.mark.asyncio
-    async def test_multiple_vehicles_shows_selection(self, flow):
-        """Multiple vehicles shows selection form."""
-        flow._vehicles = MOCK_VEHICLES_MULTI
-        await flow.async_step_select_vehicle(None)
-        flow.async_show_form.assert_called_once()
-        assert flow.async_show_form.call_args[1]["step_id"] == "select_vehicle"
-
-    @pytest.mark.asyncio
-    async def test_multiple_vehicles_without_plate_still_show_selection(self, flow):
-        flow._vehicles = [
-            {"vin": MOCK_VIN, "name": MOCK_VEHICLE_NAME, "fuel_type": "E"},
-            {"vin": "ZHWGE11S00LA00002", "name": "", "fuel_type": "E"},
-        ]
-
-        await flow.async_step_select_vehicle(None)
-
-        flow.async_show_form.assert_called_once()
-        assert flow.async_show_form.call_args[1]["step_id"] == "select_vehicle"
-
-    @pytest.mark.asyncio
-    async def test_select_vehicle_creates_entry(self, flow):
-        """Selecting a vehicle creates an entry."""
-        flow._vehicles = MOCK_VEHICLES_MULTI
-        flow._tokens = MOCK_TOKENS
-        flow._email = "test@test.com"
-        flow._scan_interval = DEFAULT_SCAN_INTERVAL
-        flow._car_refresh_interval = DEFAULT_CAR_REFRESH_INTERVAL
-        flow._device_key = MagicMock()
-        flow._device_key.pem_bytes = b"fake-pem"
-        flow._api = None
-
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
-            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
-            mock_api = MagicMock()
-            mock_api_cls.return_value = mock_api
-            flow.hass.async_add_executor_job.side_effect = [MOCK_USER_INFO]
-
-            await flow.async_step_select_vehicle({CONF_VIN: MOCK_VIN})
-
-        flow.async_create_entry.assert_called_once()
-        entry_data = flow.async_create_entry.call_args[1]["data"]
-        assert entry_data[CONF_VIN] == MOCK_VIN
 
 
 class TestAsyncStepManualVin:
@@ -321,8 +374,8 @@ class TestAsyncStepManualVin:
         assert flow.async_show_form.call_args[1]["step_id"] == "manual_vin"
 
     @pytest.mark.asyncio
-    async def test_manual_vin_creates_entry(self, flow):
-        """Manual VIN entry creates an entry."""
+    async def test_manual_vin_creates_entry_with_manual_flag(self, flow):
+        """Manual VIN entry creates an entry with manual flag."""
         flow._tokens = MOCK_TOKENS
         flow._email = "test@test.com"
         flow._scan_interval = DEFAULT_SCAN_INTERVAL
@@ -331,8 +384,12 @@ class TestAsyncStepManualVin:
         flow._device_key.pem_bytes = b"fake-pem"
         flow._api = None
 
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+        with (
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
             mock_api_cls.return_value = mock_api
@@ -342,8 +399,10 @@ class TestAsyncStepManualVin:
 
         flow.async_create_entry.assert_called_once()
         entry_data = flow.async_create_entry.call_args[1]["data"]
-        assert entry_data[CONF_VIN] == "MANUAL12345678901"
-        assert entry_data[CONF_VEHICLE_NAME] == ""
+        vehicles = entry_data[CONF_VEHICLES]
+        assert len(vehicles) == 1
+        assert vehicles[0][CONF_VIN] == "MANUAL12345678901"
+        assert vehicles[0]["manual"] is True
         assert CONF_SCAN_INTERVAL not in entry_data
 
 
@@ -365,7 +424,11 @@ class TestOptionsFlow:
         flow.hass = MagicMock()
         flow.async_show_form = MagicMock(return_value={"type": "form"})
 
-        with patch.object(type(flow), "config_entry", new_callable=lambda: property(lambda self: mock_entry)):
+        with patch.object(
+            type(flow),
+            "config_entry",
+            new_callable=lambda: property(lambda self: mock_entry),
+        ):
             await flow.async_step_init(None)
 
         flow.async_show_form.assert_called_once()
@@ -383,11 +446,17 @@ class TestOptionsFlow:
         flow.hass.config_entries.async_reload = AsyncMock()
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
-        with patch.object(type(flow), "config_entry", new_callable=lambda: property(lambda self: mock_entry)):
-            await flow.async_step_init({
-                CONF_SCAN_INTERVAL: 300,
-                CONF_CAR_REFRESH_INTERVAL: 7200,
-            })
+        with patch.object(
+            type(flow),
+            "config_entry",
+            new_callable=lambda: property(lambda self: mock_entry),
+        ):
+            await flow.async_step_init(
+                {
+                    CONF_SCAN_INTERVAL: 300,
+                    CONF_CAR_REFRESH_INTERVAL: 7200,
+                }
+            )
 
         flow.hass.config_entries.async_reload.assert_not_called()
         flow.async_create_entry.assert_called_once()
@@ -405,7 +474,18 @@ class TestReauthFlow:
         f.hass = MagicMock()
         f.hass.async_add_executor_job = AsyncMock()
         f.hass.config_entries = MagicMock()
-        f.hass.config_entries.async_get_entry.return_value = MagicMock()
+        mock_entry = MagicMock()
+        mock_entry.data = {
+            "email": "test@test.com",
+            CONF_VEHICLES: [
+                {
+                    CONF_VIN: MOCK_VIN,
+                    CONF_VEHICLE_NAME: MOCK_VEHICLE_NAME,
+                    CONF_FUEL_TYPE: "E",
+                }
+            ],
+        }
+        f.hass.config_entries.async_get_entry.return_value = mock_entry
         f.async_set_unique_id = AsyncMock()
         f._abort_if_unique_id_configured = MagicMock()
         f.async_show_form = MagicMock(return_value={"type": "form"})
@@ -427,18 +507,29 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI"):
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
-            reauth_flow.hass.async_add_executor_job.side_effect = [MOCK_TOKENS]
+            mock_api = MagicMock()
+            mock_api_cls.return_value = mock_api
+            reauth_flow.hass.async_add_executor_job.side_effect = [
+                MOCK_TOKENS,  # login
+                MOCK_VEHICLES,  # get_vehicles (for reconciliation)
+            ]
 
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "newpass",
-            })
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "newpass",
+                }
+            )
 
         reauth_flow.hass.config_entries.async_update_entry.assert_called_once()
         reauth_flow.async_abort.assert_called_once_with(reason="reauth_successful")
@@ -449,13 +540,19 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(401, "invalid-credentials")
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "wrong",
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                401, "invalid-credentials"
+            )
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "wrong",
+                }
+            )
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "invalid_auth"
@@ -465,8 +562,12 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
             reauth_flow.hass.async_add_executor_job.side_effect = [
@@ -474,10 +575,12 @@ class TestReauthFlow:
                 None,
             ]
 
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "newpass",
-            })
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "newpass",
+                }
+            )
 
         assert reauth_flow.async_show_form.call_args[1]["step_id"] == "verify"
 
@@ -486,8 +589,12 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls:
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+        ):
             mock_auth = MagicMock()
             mock_auth_cls.return_value = mock_auth
             reauth_flow.hass.async_add_executor_job.side_effect = [
@@ -495,10 +602,12 @@ class TestReauthFlow:
                 HondaAuthError(401, "reset failed"),
             ]
 
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "newpass",
-            })
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "newpass",
+                }
+            )
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
@@ -508,29 +617,43 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(401, "locked-account")
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "wrong",
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                401, "locked-account"
+            )
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "wrong",
+                }
+            )
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "account_locked"
 
     @pytest.mark.asyncio
-    async def test_reauth_unknown_honda_auth_error_shows_cannot_connect(self, reauth_flow):
+    async def test_reauth_unknown_honda_auth_error_shows_cannot_connect(
+        self, reauth_flow
+    ):
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(500, "something-else")
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "wrong",
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            reauth_flow.hass.async_add_executor_job.side_effect = HondaAuthError(
+                500, "something-else"
+            )
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "wrong",
+                }
+            )
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
@@ -540,13 +663,19 @@ class TestReauthFlow:
         reauth_flow.context = {"entry_id": "test_entry"}
         await reauth_flow.async_step_reauth({})
 
-        with patch("custom_components.myhondaplus.config_flow.DeviceKey"), \
-             patch("custom_components.myhondaplus.config_flow.HondaAuth"):
-            reauth_flow.hass.async_add_executor_job.side_effect = Exception("unexpected")
-            await reauth_flow.async_step_reauth_confirm({
-                "email": "test@test.com",
-                "password": "wrong",
-            })
+        with (
+            patch("custom_components.myhondaplus.config_flow.DeviceKey"),
+            patch("custom_components.myhondaplus.config_flow.HondaAuth"),
+        ):
+            reauth_flow.hass.async_add_executor_job.side_effect = Exception(
+                "unexpected"
+            )
+            await reauth_flow.async_step_reauth_confirm(
+                {
+                    "email": "test@test.com",
+                    "password": "wrong",
+                }
+            )
 
         errors = reauth_flow.async_show_form.call_args[1]["errors"]
         assert errors["base"] == "cannot_connect"
@@ -556,21 +685,40 @@ class TestFetchVehiclesAndCreateEntry:
     @pytest.mark.asyncio
     async def test_fetch_vehicles_reauth_short_circuits(self, flow):
         flow._reauth_entry = MagicMock()
+        flow._reauth_entry.data = {"email": "test@test.com", CONF_VEHICLES: []}
         flow._tokens = MOCK_TOKENS
-        flow._update_reauth_entry = MagicMock(return_value={"type": "abort"})
+        flow._device_key = MagicMock()
+        flow._device_key.pem_bytes = b"fake-pem"
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
 
-        result = await flow._fetch_vehicles_and_continue()
+        with (
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
+            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
+            mock_api = MagicMock()
+            mock_api_cls.return_value = mock_api
+            flow.hass.async_add_executor_job.side_effect = [MOCK_VEHICLES]
+
+            result = await flow._fetch_vehicles_and_continue()
 
         assert result == {"type": "abort"}
-        flow._update_reauth_entry.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_fetch_vehicles_exception_falls_back_to_manual_vin(self, flow):
         flow._tokens = MOCK_TOKENS
-        flow.async_step_manual_vin = AsyncMock(return_value={"type": "form", "step_id": "manual_vin"})
+        flow.async_step_manual_vin = AsyncMock(
+            return_value={"type": "form", "step_id": "manual_vin"}
+        )
 
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+        with (
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
             mock_api_cls.return_value = mock_api
@@ -582,42 +730,80 @@ class TestFetchVehiclesAndCreateEntry:
         flow.async_step_manual_vin.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_fetch_vehicles_multiple_entries_goes_to_selection(self, flow):
-        flow._tokens = MOCK_TOKENS
-        flow.async_step_select_vehicle = AsyncMock(return_value={"type": "form", "step_id": "select_vehicle"})
-
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
-            mock_auth_cls.extract_user_id.return_value = "fake-user-id"
-            mock_api = MagicMock()
-            mock_api_cls.return_value = mock_api
-            flow.hass.async_add_executor_job.side_effect = [MOCK_VEHICLES_MULTI]
-
-            result = await flow._fetch_vehicles_and_continue()
-
-        assert result["step_id"] == "select_vehicle"
-        flow.async_step_select_vehicle.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_create_entry_personal_id_fallback_and_title_fallback(self, flow):
+    async def test_create_entry_personal_id_fallback(self, flow):
         flow._tokens = MOCK_TOKENS
         flow._email = "test@test.com"
+        flow._vehicles = [{"vin": "VIN12345678901234", "name": "", "fuel_type": ""}]
         flow._scan_interval = DEFAULT_SCAN_INTERVAL
         flow._car_refresh_interval = DEFAULT_CAR_REFRESH_INTERVAL
+        flow._location_refresh_interval = 3600
         flow._device_key = MagicMock()
         flow._device_key.pem_bytes = b"fake-pem"
         flow._api = None
 
-        with patch("custom_components.myhondaplus.config_flow.HondaAuth") as mock_auth_cls, \
-             patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls:
+        with (
+            patch(
+                "custom_components.myhondaplus.config_flow.HondaAuth"
+            ) as mock_auth_cls,
+            patch("custom_components.myhondaplus.config_flow.HondaAPI") as mock_api_cls,
+        ):
             mock_auth_cls.extract_user_id.return_value = "fake-user-id"
             mock_api = MagicMock()
             mock_api_cls.return_value = mock_api
             flow.hass.async_add_executor_job.side_effect = [Exception("boom")]
 
-            await flow._create_entry("VIN12345678901234", "", "")
+            await flow._create_entry()
 
         flow.async_create_entry.assert_called_once()
-        assert flow.async_create_entry.call_args[1]["title"] == "Honda 901234"
+        assert "test@test.com" in flow.async_create_entry.call_args[1]["title"]
         assert flow.async_create_entry.call_args[1]["data"]["personal_id"] == ""
-        assert flow.async_create_entry.call_args[1]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+        assert (
+            flow.async_create_entry.call_args[1]["options"][CONF_SCAN_INTERVAL]
+            == DEFAULT_SCAN_INTERVAL
+        )
+
+
+class TestReconcileVehicles:
+    def test_new_vin_appended(self):
+        existing = [{CONF_VIN: "VIN1", CONF_VEHICLE_NAME: "Car 1", CONF_FUEL_TYPE: "E"}]
+        api = [
+            {"vin": "VIN1", "name": "Car 1", "fuel_type": "E"},
+            {"vin": "VIN2", "name": "Car 2", "fuel_type": "H"},
+        ]
+        result = _reconcile_vehicles(existing, api)
+        assert len(result) == 2
+        assert {v[CONF_VIN] for v in result} == {"VIN1", "VIN2"}
+
+    def test_removed_vin_dropped(self):
+        existing = [
+            {CONF_VIN: "VIN1", CONF_VEHICLE_NAME: "Car 1", CONF_FUEL_TYPE: "E"},
+            {CONF_VIN: "VIN2", CONF_VEHICLE_NAME: "Car 2", CONF_FUEL_TYPE: "H"},
+        ]
+        api = [{"vin": "VIN1", "name": "Car 1", "fuel_type": "E"}]
+        result = _reconcile_vehicles(existing, api)
+        assert len(result) == 1
+        assert result[0][CONF_VIN] == "VIN1"
+
+    def test_manual_vin_preserved(self):
+        existing = [
+            {
+                CONF_VIN: "MANUAL1",
+                CONF_VEHICLE_NAME: "",
+                CONF_FUEL_TYPE: "",
+                "manual": True,
+            }
+        ]
+        api = [{"vin": "VIN1", "name": "Car 1", "fuel_type": "E"}]
+        result = _reconcile_vehicles(existing, api)
+        assert len(result) == 2
+        manual = [v for v in result if v.get("manual")]
+        assert len(manual) == 1
+
+    def test_existing_vin_name_updated(self):
+        existing = [
+            {CONF_VIN: "VIN1", CONF_VEHICLE_NAME: "Old Name", CONF_FUEL_TYPE: "E"}
+        ]
+        api = [{"vin": "VIN1", "name": "New Name", "fuel_type": "H"}]
+        result = _reconcile_vehicles(existing, api)
+        assert result[0][CONF_VEHICLE_NAME] == "New Name"
+        assert result[0][CONF_FUEL_TYPE] == "H"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for the coordinator."""
 
 from collections import namedtuple
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -45,7 +46,7 @@ def coordinator(mock_hass, mock_entry):
         coord.vin = MOCK_VIN
         coord.api = MagicMock()
         coord.api.tokens = Tokens("fake-access-token", "fake-refresh-token")
-        coord.data = dict(MOCK_DASHBOARD_DATA)
+        coord.data = replace(MOCK_DASHBOARD_DATA)
         coord.logger = MagicMock()
         coord._service_available = True
         coord._vehicle_name = MOCK_VEHICLE_NAME
@@ -73,7 +74,7 @@ def trip_coordinator(mock_hass, mock_entry):
 class TestHondaDataUpdateCoordinator:
     @pytest.mark.asyncio
     async def test_update_success(self, coordinator):
-        coordinator.hass.async_add_executor_job.return_value = dict(MOCK_DASHBOARD_DATA)
+        coordinator.hass.async_add_executor_job.return_value = replace(MOCK_DASHBOARD_DATA)
         result = await coordinator._async_update_data()
         assert result["battery_level"] == 75
 
@@ -138,7 +139,7 @@ class TestHondaDataUpdateCoordinator:
             coordinator.hass.async_add_executor_job.side_effect = [
                 HondaAPIError(503, "Service Unavailable"),
                 HondaAPIError(503, "Service Unavailable"),
-                dict(MOCK_DASHBOARD_DATA),
+                replace(MOCK_DASHBOARD_DATA),
             ]
 
             assert await coordinator._async_update_data() == coordinator.data
@@ -157,7 +158,7 @@ class TestHondaDataUpdateCoordinator:
             SimpleNamespace(
                 success=True, status="success", timed_out=False, reason=None
             ),
-            dict(MOCK_DASHBOARD_DATA),
+            replace(MOCK_DASHBOARD_DATA),
         ]
         await coordinator.async_refresh_from_car()
         coordinator.async_set_updated_data.assert_called_once()
@@ -338,7 +339,7 @@ class TestHondaDataUpdateCoordinator:
             SimpleNamespace(
                 success=True, status="success", timed_out=False, reason=None
             ),
-            dict(MOCK_DASHBOARD_DATA),
+            replace(MOCK_DASHBOARD_DATA),
         ]
 
         await coordinator.async_refresh_location()
@@ -356,7 +357,7 @@ class TestHondaDataUpdateCoordinator:
             coordinator._fetch_data,
         )
         coordinator.async_set_updated_data.assert_called_once_with(
-            dict(MOCK_DASHBOARD_DATA)
+            replace(MOCK_DASHBOARD_DATA)
         )
 
     @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -36,7 +36,9 @@ def mock_entry():
 
 @pytest.fixture
 def coordinator(mock_hass, mock_entry):
-    with patch.object(HondaDataUpdateCoordinator, "__init__", lambda self, *a, **kw: None):
+    with patch.object(
+        HondaDataUpdateCoordinator, "__init__", lambda self, *a, **kw: None
+    ):
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.hass = mock_hass
         coord.entry = mock_entry
@@ -77,38 +79,50 @@ class TestHondaDataUpdateCoordinator:
 
     @pytest.mark.asyncio
     async def test_update_401_raises_auth_failed(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(401, "Unauthorized")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(
+            401, "Unauthorized"
+        )
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
     async def test_update_502_returns_cached_data(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            502, "Bad Gateway"
+        )
         result = await coordinator._async_update_data()
         assert result == coordinator.data
 
     @pytest.mark.asyncio
     async def test_update_500_returns_cached_data(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Internal Server Error")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            500, "Internal Server Error"
+        )
         result = await coordinator._async_update_data()
         assert result == coordinator.data
 
     @pytest.mark.asyncio
     async def test_update_503_returns_cached_data(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(503, "Service Unavailable")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            503, "Service Unavailable"
+        )
         result = await coordinator._async_update_data()
         assert result == coordinator.data
 
     @pytest.mark.asyncio
     async def test_update_500_no_cached_data_raises(self, coordinator):
         coordinator.data = None
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Internal Server Error")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            500, "Internal Server Error"
+        )
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
     async def test_update_400_raises_update_failed(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(400, "Bad Request")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            400, "Bad Request"
+        )
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
 
@@ -132,14 +146,17 @@ class TestHondaDataUpdateCoordinator:
             await coordinator._async_update_data()
 
         logger.warning.assert_called_once_with(
-            "Honda API unavailable (%s), keeping cached vehicle data", 503,
+            "Honda API unavailable (%s), keeping cached vehicle data",
+            503,
         )
         logger.info.assert_called_once_with("Connection to Honda API restored")
 
     @pytest.mark.asyncio
     async def test_refresh_from_car_success(self, coordinator):
         coordinator.hass.async_add_executor_job.side_effect = [
-            SimpleNamespace(success=True, status="success", timed_out=False, reason=None),
+            SimpleNamespace(
+                success=True, status="success", timed_out=False, reason=None
+            ),
             dict(MOCK_DASHBOARD_DATA),
         ]
         await coordinator.async_refresh_from_car()
@@ -153,13 +170,17 @@ class TestHondaDataUpdateCoordinator:
 
     @pytest.mark.asyncio
     async def test_refresh_from_car_401(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(401, "Unauthorized")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(
+            401, "Unauthorized"
+        )
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator.async_refresh_from_car()
 
     @pytest.mark.asyncio
     async def test_refresh_from_car_502(self, coordinator):
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            502, "Bad Gateway"
+        )
         with pytest.raises(HomeAssistantError) as exc_info:
             await coordinator.async_refresh_from_car()
         assert exc_info.value.translation_key == "refresh_data_failed"
@@ -167,11 +188,16 @@ class TestHondaDataUpdateCoordinator:
     @pytest.mark.asyncio
     async def test_refresh_from_car_timeout_raises(self, coordinator):
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="pending", timed_out=True, reason=None,
+            success=False,
+            status="pending",
+            timed_out=True,
+            reason=None,
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            with patch(
+                "custom_components.myhondaplus.coordinator.pn_async_create"
+            ) as pn_create:
                 with pytest.raises(HomeAssistantError) as exc_info:
                     await coordinator.async_refresh_from_car()
                 assert exc_info.value.translation_key == "refresh_data_failed"
@@ -192,10 +218,15 @@ class TestHondaDataUpdateCoordinator:
     @pytest.mark.asyncio
     async def test_refresh_from_car_failure_no_notification(self, coordinator):
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="failed", timed_out=False, reason="error",
+            success=False,
+            status="failed",
+            timed_out=False,
+            reason="error",
         )
 
-        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+        with patch(
+            "custom_components.myhondaplus.coordinator.pn_async_create"
+        ) as pn_create:
             with pytest.raises(HomeAssistantError) as exc_info:
                 await coordinator.async_refresh_from_car()
             assert exc_info.value.translation_key == "refresh_data_failed"
@@ -208,19 +239,25 @@ class TestHondaDataUpdateCoordinator:
         coordinator.hass.async_add_executor_job.return_value = "ok"
         result = await coordinator.async_send_command(func, "arg1", "arg2")
         assert result == "ok"
-        coordinator.hass.async_add_executor_job.assert_awaited_once_with(func, "arg1", "arg2")
+        coordinator.hass.async_add_executor_job.assert_awaited_once_with(
+            func, "arg1", "arg2"
+        )
 
     @pytest.mark.asyncio
     async def test_send_command_401(self, coordinator):
         func = MagicMock()
-        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(401, "Unauthorized")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(
+            401, "Unauthorized"
+        )
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator.async_send_command(func)
 
     @pytest.mark.asyncio
     async def test_send_command_500(self, coordinator):
         func = MagicMock()
-        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Error")
+        coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            500, "Error"
+        )
         with pytest.raises(HomeAssistantError) as exc_info:
             await coordinator.async_send_command(func)
         assert exc_info.value.translation_key == "send_command_failed"
@@ -230,13 +267,18 @@ class TestHondaDataUpdateCoordinator:
         func = MagicMock()
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=True, status="success", timed_out=False, reason=None,
+            success=True,
+            status="success",
+            timed_out=False,
+            reason=None,
         )
 
         assert await coordinator.async_send_command_and_wait(func, "arg1") is True
 
         coordinator.hass.async_add_executor_job.assert_awaited_once_with(
-            coordinator.api.wait_for_command, "cmd-123", 90,
+            coordinator.api.wait_for_command,
+            "cmd-123",
+            90,
         )
 
     @pytest.mark.asyncio
@@ -244,12 +286,19 @@ class TestHondaDataUpdateCoordinator:
         func = MagicMock()
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="timeout", timed_out=True, reason=None,
+            success=False,
+            status="timeout",
+            timed_out=True,
+            reason=None,
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
-                assert await coordinator.async_send_command_and_wait(func, "arg1") is False
+            with patch(
+                "custom_components.myhondaplus.coordinator.pn_async_create"
+            ) as pn_create:
+                assert (
+                    await coordinator.async_send_command_and_wait(func, "arg1") is False
+                )
 
         logger.warning.assert_called_once_with(
             "Command timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
@@ -269,10 +318,15 @@ class TestHondaDataUpdateCoordinator:
         func = MagicMock()
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="failed", timed_out=False, reason="error",
+            success=False,
+            status="failed",
+            timed_out=False,
+            reason="error",
         )
 
-        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+        with patch(
+            "custom_components.myhondaplus.coordinator.pn_async_create"
+        ) as pn_create:
             assert await coordinator.async_send_command_and_wait(func, "arg1") is False
 
         pn_create.assert_not_called()
@@ -281,39 +335,53 @@ class TestHondaDataUpdateCoordinator:
     async def test_refresh_location_success(self, coordinator):
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.side_effect = [
-            SimpleNamespace(success=True, status="success", timed_out=False, reason=None),
+            SimpleNamespace(
+                success=True, status="success", timed_out=False, reason=None
+            ),
             dict(MOCK_DASHBOARD_DATA),
         ]
 
         await coordinator.async_refresh_location()
 
         coordinator.async_send_command.assert_awaited_once_with(
-            coordinator.api.request_car_location, MOCK_VIN,
+            coordinator.api.request_car_location,
+            MOCK_VIN,
         )
         assert coordinator.hass.async_add_executor_job.await_args_list[0].args == (
-            coordinator.api.wait_for_command, "cmd-123", 90,
+            coordinator.api.wait_for_command,
+            "cmd-123",
+            90,
         )
         assert coordinator.hass.async_add_executor_job.await_args_list[1].args == (
             coordinator._fetch_data,
         )
-        coordinator.async_set_updated_data.assert_called_once_with(dict(MOCK_DASHBOARD_DATA))
+        coordinator.async_set_updated_data.assert_called_once_with(
+            dict(MOCK_DASHBOARD_DATA)
+        )
 
     @pytest.mark.asyncio
     async def test_refresh_location_command_failure_raises(self, coordinator):
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="timeout", timed_out=True, reason=None,
+            success=False,
+            status="timeout",
+            timed_out=True,
+            reason=None,
         )
 
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
-            with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+            with patch(
+                "custom_components.myhondaplus.coordinator.pn_async_create"
+            ) as pn_create:
                 with pytest.raises(HomeAssistantError) as exc_info:
                     await coordinator.async_refresh_location()
                 assert exc_info.value.translation_key == "refresh_location_failed"
 
         coordinator.async_set_updated_data.assert_not_called()
         coordinator.hass.async_add_executor_job.assert_awaited_once_with(
-            coordinator.api.wait_for_command, "cmd-123", 90,
+            coordinator.api.wait_for_command,
+            "cmd-123",
+            90,
         )
         logger.warning.assert_called_once_with(
             "Location refresh timed out waiting for the car to respond (id=%s, status=%s, reason=%s)",
@@ -332,10 +400,15 @@ class TestHondaDataUpdateCoordinator:
     async def test_refresh_location_timeout_without_notification(self, coordinator):
         coordinator.async_send_command = AsyncMock(return_value="cmd-123")
         coordinator.hass.async_add_executor_job.return_value = SimpleNamespace(
-            success=False, status="timeout", timed_out=True, reason=None,
+            success=False,
+            status="timeout",
+            timed_out=True,
+            reason=None,
         )
 
-        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+        with patch(
+            "custom_components.myhondaplus.coordinator.pn_async_create"
+        ) as pn_create:
             with pytest.raises(HomeAssistantError) as exc_info:
                 await coordinator.async_refresh_location(notify_on_timeout=False)
             assert exc_info.value.translation_key == "refresh_location_failed"
@@ -352,31 +425,41 @@ class TestHondaTripCoordinator:
 
     @pytest.mark.asyncio
     async def test_update_401_raises_auth_failed(self, trip_coordinator):
-        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(401, "Unauthorized")
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAuthError(
+            401, "Unauthorized"
+        )
         with pytest.raises(ConfigEntryAuthFailed):
             await trip_coordinator._async_update_data()
 
     @pytest.mark.asyncio
     async def test_update_502_returns_cached_data(self, trip_coordinator):
-        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(502, "Bad Gateway")
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            502, "Bad Gateway"
+        )
         result = await trip_coordinator._async_update_data()
         assert result == trip_coordinator.data
 
     @pytest.mark.asyncio
     async def test_update_500_no_cached_data_raises(self, trip_coordinator):
         trip_coordinator.data = None
-        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(500, "Error")
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            500, "Error"
+        )
         with pytest.raises(UpdateFailed):
             await trip_coordinator._async_update_data()
 
     @pytest.mark.asyncio
     async def test_update_400_raises_update_failed(self, trip_coordinator):
-        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(400, "Bad Request")
+        trip_coordinator.hass.async_add_executor_job.side_effect = HondaAPIError(
+            400, "Bad Request"
+        )
         with pytest.raises(UpdateFailed):
             await trip_coordinator._async_update_data()
 
     @pytest.mark.asyncio
-    async def test_update_logs_unavailable_once_and_recovered_once(self, trip_coordinator):
+    async def test_update_logs_unavailable_once_and_recovered_once(
+        self, trip_coordinator
+    ):
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
             trip_coordinator.hass.async_add_executor_job.side_effect = [
                 HondaAPIError(502, "Bad Gateway"),
@@ -389,6 +472,7 @@ class TestHondaTripCoordinator:
             await trip_coordinator._async_update_data()
 
         logger.warning.assert_called_once_with(
-            "Honda API unavailable (%s), keeping cached trip data", 502,
+            "Honda API unavailable (%s), keeping cached trip data",
+            502,
         )
         logger.info.assert_called_once_with("Connection to Honda API restored")

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -17,37 +17,37 @@ def make_tracker(coordinator):
 class TestDeviceTracker:
     def test_latitude_decimal_string(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data["latitude"] = "45.123"
+        mock_coordinator.data.latitude = "45.123"
         assert tracker.latitude == 45.123
 
     def test_longitude_decimal_string(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data["longitude"] = "9.456"
+        mock_coordinator.data.longitude = "9.456"
         assert tracker.longitude == 9.456
 
     def test_latitude_dms(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data["latitude"] = "43,33,12.391"
+        mock_coordinator.data.latitude = "43,33,12.391"
         assert abs(tracker.latitude - 43.55344) < 0.0001
 
     def test_longitude_dms(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data["longitude"] = "010,19,56.497"
+        mock_coordinator.data.longitude = "010,19,56.497"
         assert abs(tracker.longitude - 10.33236) < 0.0001
 
     def test_latitude_none(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data.pop("latitude", None)
+        mock_coordinator.data.latitude = None
         assert tracker.latitude is None
 
     def test_longitude_none(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data.pop("longitude", None)
+        mock_coordinator.data.longitude = None
         assert tracker.longitude is None
 
     def test_latitude_numeric(self, mock_coordinator):
         tracker = make_tracker(mock_coordinator)
-        mock_coordinator.data["latitude"] = 45.0
+        mock_coordinator.data.latitude = 45.0
         assert tracker.latitude == 45.0
 
     def test_source_type(self, mock_coordinator):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,6 @@
 """Tests for diagnostics."""
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,7 +26,7 @@ def mock_entry_for_diag(mock_runtime_data):
     entry.as_dict.return_value = dict(MOCK_ENTRY_DATA)
     entry.runtime_data = mock_runtime_data
     # Set realistic data on the vehicle's coordinators
-    entry.runtime_data.vehicles[MOCK_VIN].coordinator.data = dict(MOCK_DASHBOARD_DATA)
+    entry.runtime_data.vehicles[MOCK_VIN].coordinator.data = replace(MOCK_DASHBOARD_DATA)
     entry.runtime_data.vehicles[MOCK_VIN].trip_coordinator.data = dict(MOCK_TRIP_DATA)
     return entry
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -16,18 +16,17 @@ from custom_components.myhondaplus.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 
-from .conftest import MOCK_DASHBOARD_DATA, MOCK_ENTRY_DATA, MOCK_TRIP_DATA
+from .conftest import MOCK_DASHBOARD_DATA, MOCK_ENTRY_DATA, MOCK_TRIP_DATA, MOCK_VIN
 
 
 @pytest.fixture
-def mock_entry_for_diag(mock_coordinator, mock_trip_coordinator):
+def mock_entry_for_diag(mock_runtime_data):
     entry = MagicMock()
     entry.as_dict.return_value = dict(MOCK_ENTRY_DATA)
-    entry.runtime_data = MagicMock()
-    entry.runtime_data.coordinator = mock_coordinator
-    entry.runtime_data.coordinator.data = dict(MOCK_DASHBOARD_DATA)
-    entry.runtime_data.trip_coordinator = mock_trip_coordinator
-    entry.runtime_data.trip_coordinator.data = dict(MOCK_TRIP_DATA)
+    entry.runtime_data = mock_runtime_data
+    # Set realistic data on the vehicle's coordinators
+    entry.runtime_data.vehicles[MOCK_VIN].coordinator.data = dict(MOCK_DASHBOARD_DATA)
+    entry.runtime_data.vehicles[MOCK_VIN].trip_coordinator.data = dict(MOCK_TRIP_DATA)
     return entry
 
 
@@ -46,20 +45,22 @@ class TestDiagnostics:
         hass = MagicMock()
         result = await async_get_config_entry_diagnostics(hass, mock_entry_for_diag)
         assert "config_entry" in result
-        assert "coordinator_data" in result
-        assert "trip_data" in result
+        assert "vehicles" in result
+        assert MOCK_VIN in result["vehicles"]
+        assert "coordinator_data" in result["vehicles"][MOCK_VIN]
+        assert "trip_data" in result["vehicles"][MOCK_VIN]
 
     @pytest.mark.asyncio
     async def test_coordinator_data_included(self, mock_entry_for_diag):
         hass = MagicMock()
         result = await async_get_config_entry_diagnostics(hass, mock_entry_for_diag)
-        assert result["coordinator_data"]["battery_level"] == 75
+        assert result["vehicles"][MOCK_VIN]["coordinator_data"]["battery_level"] == 75
 
     @pytest.mark.asyncio
     async def test_trip_data_included(self, mock_entry_for_diag):
         hass = MagicMock()
         result = await async_get_config_entry_diagnostics(hass, mock_entry_for_diag)
-        assert result["trip_data"]["trips"] == 15
+        assert result["vehicles"][MOCK_VIN]["trip_data"]["trips"] == 15
 
     @pytest.mark.asyncio
     async def test_sensitive_fields_redacted(self, mock_entry_for_diag):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -7,11 +7,13 @@ from custom_components.myhondaplus.entity import FUEL_TYPE_LABELS, MyHondaPlusEn
 from .conftest import MOCK_VEHICLE_NAME, MOCK_VIN
 
 
-def make_entity(coordinator, vin=MOCK_VIN, vehicle_name=MOCK_VEHICLE_NAME):
+def make_entity(
+    coordinator, vin=MOCK_VIN, vehicle_name=MOCK_VEHICLE_NAME, fuel_type="E"
+):
     """Create a MyHondaPlusEntity instance."""
     desc = MagicMock()
     desc.key = "test_key"
-    entity = MyHondaPlusEntity(coordinator, desc, vin, vehicle_name)
+    entity = MyHondaPlusEntity(coordinator, desc, vin, vehicle_name, fuel_type)
     entity.hass = MagicMock()
     return entity
 
@@ -39,8 +41,7 @@ class TestMyHondaPlusEntity:
         assert info["model"] == "Electric"
 
     def test_device_info_model_no_fuel_type(self, mock_coordinator):
-        mock_coordinator.entry.data["fuel_type"] = ""
-        entity = make_entity(mock_coordinator)
+        entity = make_entity(mock_coordinator, fuel_type="")
         info = entity.device_info
         assert "model" not in info
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from custom_components.myhondaplus.entity import FUEL_TYPE_LABELS, MyHondaPlusEntity
+from custom_components.myhondaplus.entity import MyHondaPlusEntity
 
 from .conftest import MOCK_VEHICLE_NAME, MOCK_VIN
 
@@ -35,21 +35,11 @@ class TestMyHondaPlusEntity:
         info = entity.device_info
         assert info["name"] == f"Honda {MOCK_VIN[-6:]}"
 
-    def test_device_info_model_electric(self, mock_coordinator):
+    def test_device_info_no_model_on_entity(self, mock_coordinator):
+        """Model is set via device registry, not by the entity."""
         entity = make_entity(mock_coordinator)
         info = entity.device_info
-        assert info["model"] == "Electric"
-
-    def test_device_info_model_no_fuel_type(self, mock_coordinator):
-        entity = make_entity(mock_coordinator, fuel_type="")
-        info = entity.device_info
         assert "model" not in info
-
-    def test_fuel_type_labels(self):
-        assert FUEL_TYPE_LABELS["E"] == "Electric"
-        assert FUEL_TYPE_LABELS["H"] == "Hybrid"
-        assert FUEL_TYPE_LABELS["G"] == "Gasoline"
-        assert FUEL_TYPE_LABELS["D"] == "Diesel"
 
     def test_has_entity_name(self, mock_coordinator):
         entity = make_entity(mock_coordinator)

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -11,10 +11,19 @@ import voluptuous as vol
 from homeassistant.const import PERCENTAGE
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
-from pymyhondaplus.api import EVStatus, HondaAPIError
+from pymyhondaplus.api import (
+    EVStatus,
+    HondaAPIError,
+    HondaAuthError,
+    UIConfiguration,
+    Vehicle,
+    VehicleCapabilities,
+)
 
 from custom_components.myhondaplus import (
+    _build_model_name_from_vehicle,
     _cleanup_removed_vehicles,
+    _fetch_vehicle_metadata,
     _schedule_car_refresh,
     _schedule_location_refresh,
     _validate_days,
@@ -31,6 +40,7 @@ from custom_components.myhondaplus.button import (
 from custom_components.myhondaplus.button import (
     async_setup_entry as button_setup_entry,
 )
+from custom_components.myhondaplus.config_flow import MyHondaPlusConfigFlow
 from custom_components.myhondaplus.coordinator import (
     DashboardData,
     HondaDataUpdateCoordinator,
@@ -65,6 +75,7 @@ from custom_components.myhondaplus.sensor import (
     HondaSensor,
     HondaTripSensor,
     _resolve_unit,
+    _sensor_enabled,
 )
 from custom_components.myhondaplus.sensor import (
     async_setup_entry as sensor_setup_entry,
@@ -758,3 +769,163 @@ class TestDefrostSwitchSuccess:
         mock_coordinator.async_set_updated_data.assert_called_once()
         updated = mock_coordinator.async_set_updated_data.call_args[0][0]
         assert updated["climate_defrost"] is True
+
+
+class TestBuildModelNameFromVehicle:
+    """Tests for _build_model_name_from_vehicle."""
+
+    def test_friendly_and_grade_and_year(self):
+        v = SimpleNamespace(model_name="Honda e", grade="Advance", model_year="2024")
+        assert _build_model_name_from_vehicle(v) == "Honda e Advance (2024)"
+
+    def test_friendly_and_grade_with_prefix(self):
+        v = SimpleNamespace(model_name="ZR-V", grade="2X Sport", model_year="2025")
+        assert _build_model_name_from_vehicle(v) == "ZR-V Sport (2025)"
+
+    def test_only_grade(self):
+        v = SimpleNamespace(model_name="", grade="Advance", model_year="")
+        assert _build_model_name_from_vehicle(v) == "Advance"
+
+    def test_only_year(self):
+        v = SimpleNamespace(model_name="", grade="", model_year="2024")
+        assert _build_model_name_from_vehicle(v) == "2024"
+
+    def test_empty(self):
+        v = SimpleNamespace(model_name="", grade="", model_year="")
+        assert _build_model_name_from_vehicle(v) == ""
+
+
+class TestFetchVehicleMetadata:
+    """Tests for _fetch_vehicle_metadata."""
+
+    @pytest.mark.asyncio
+    async def test_returns_vehicles_by_vin(self):
+        vehicle = Vehicle(vin=MOCK_VIN, model_name="Honda e")
+        api = MagicMock()
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(return_value=[vehicle])
+        entry = MagicMock()
+        entry.data = {**MOCK_ENTRY_DATA}
+
+        result = await _fetch_vehicle_metadata(hass, entry, api)
+        assert MOCK_VIN in result
+        assert result[MOCK_VIN].model_name == "Honda e"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_exception(self):
+        api = MagicMock()
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=Exception("fail"))
+        entry = MagicMock()
+        entry.data = {**MOCK_ENTRY_DATA}
+
+        result = await _fetch_vehicle_metadata(hass, entry, api)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_backfills_model_name(self):
+        from custom_components.myhondaplus.const import CONF_VEHICLES, CONF_VIN
+
+        vehicle = Vehicle(vin=MOCK_VIN, model_name="Honda e", grade="Advance", model_year="2024")
+        api = MagicMock()
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(return_value=[vehicle])
+        entry = MagicMock()
+        entry.data = {
+            **MOCK_ENTRY_DATA,
+            CONF_VEHICLES: [{CONF_VIN: MOCK_VIN}],  # no model
+        }
+
+        await _fetch_vehicle_metadata(hass, entry, api)
+        hass.config_entries.async_update_entry.assert_called_once()
+
+
+class TestSensorEnabled:
+    """Tests for _sensor_enabled capability/ui_hide filtering."""
+
+    def test_no_capability_always_enabled(self):
+        desc = SimpleNamespace(capability="", ui_hide="")
+        vehicle = SimpleNamespace(
+            capabilities=VehicleCapabilities(),
+            ui_config=UIConfiguration(),
+        )
+        assert _sensor_enabled(desc, vehicle) is True
+
+    def test_capability_false_disables(self):
+        desc = SimpleNamespace(capability="remote_charge", ui_hide="")
+        vehicle = SimpleNamespace(
+            capabilities=VehicleCapabilities(remote_charge=False),
+            ui_config=UIConfiguration(),
+        )
+        assert _sensor_enabled(desc, vehicle) is False
+
+    def test_ui_hide_true_disables(self):
+        desc = SimpleNamespace(capability="", ui_hide="hide_internal_temperature")
+        vehicle = SimpleNamespace(
+            capabilities=VehicleCapabilities(),
+            ui_config=UIConfiguration(hide_internal_temperature=True),
+        )
+        assert _sensor_enabled(desc, vehicle) is False
+
+
+class TestCommandValueError:
+    """Test that ValueError from capability checks is caught."""
+
+    @pytest.mark.asyncio
+    async def test_valueerror_raises_ha_error(self):
+        coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
+        coord.hass = MagicMock()
+        coord.hass.async_add_executor_job = AsyncMock(
+            side_effect=ValueError("not supported")
+        )
+        with pytest.raises(HomeAssistantError):
+            await coord.async_send_command(lambda: None)
+
+
+class TestConfigFlowDeviceRegistrationError:
+    """Test that network errors during device registration are caught."""
+
+    @pytest.mark.asyncio
+    async def test_login_device_reset_network_error(self):
+        flow = MyHondaPlusConfigFlow()
+        flow.hass = MagicMock()
+        flow._email = "test@example.com"
+        flow._password = "password"
+        flow._device_key = MagicMock()
+        flow._auth = MagicMock()
+
+        # First call (login) raises device-not-registered
+        # Second call (reset) raises a network error
+        flow.hass.async_add_executor_job = AsyncMock(
+            side_effect=[
+                HondaAuthError(403, "device-authenticator-not-registered"),
+                Exception("ReadTimeout"),
+            ]
+        )
+
+        result = await flow.async_step_user({
+            "email": "test@example.com",
+            "password": "password",
+        })
+        assert result["errors"]["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_reauth_device_reset_network_error(self):
+        flow = MyHondaPlusConfigFlow()
+        flow.hass = MagicMock()
+        flow._reauth_entry = MagicMock()
+        flow._device_key = MagicMock()
+        flow._auth = MagicMock()
+
+        flow.hass.async_add_executor_job = AsyncMock(
+            side_effect=[
+                HondaAuthError(403, "device-authenticator-not-registered"),
+                Exception("ReadTimeout"),
+            ]
+        )
+
+        result = await flow.async_step_reauth_confirm({
+            "email": "test@example.com",
+            "password": "password",
+        })
+        assert result["errors"]["base"] == "cannot_connect"

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -33,6 +33,7 @@ from custom_components.myhondaplus.coordinator import (
     HondaDataUpdateCoordinator,
     HondaTripCoordinator,
 )
+from custom_components.myhondaplus.data import VehicleData
 from custom_components.myhondaplus.device_tracker import (
     _dms_to_decimal,
 )
@@ -90,37 +91,55 @@ def _make_hass_mock():
     return hass
 
 
+def _make_entry_with_vehicles(coordinator, trip_coordinator=None):
+    """Create a mock entry with the new vehicles-based runtime_data."""
+    vd = VehicleData(
+        coordinator=coordinator,
+        trip_coordinator=trip_coordinator or MagicMock(),
+        vin=MOCK_VIN,
+        vehicle_name=MOCK_VEHICLE_NAME,
+        fuel_type="E",
+    )
+    return SimpleNamespace(
+        runtime_data=SimpleNamespace(
+            vehicles={MOCK_VIN: vd},
+            api=MagicMock(),
+        ),
+        data=dict(MOCK_ENTRY_DATA),
+    )
+
+
 def make_base_entity(coordinator, key="test_key", vehicle_name=MOCK_VEHICLE_NAME):
     desc = EntityDescription(key=key)
-    entity = MyHondaPlusEntity(coordinator, desc, MOCK_VIN, vehicle_name)
+    entity = MyHondaPlusEntity(coordinator, desc, MOCK_VIN, vehicle_name, "E")
     entity.hass = _make_hass_mock()
     return entity
 
 
 def make_button(coordinator, key):
     desc = next(d for d in BUTTON_DESCRIPTIONS if d.key == key)
-    entity = HondaButton(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME)
+    entity = HondaButton(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
     entity.hass = _make_hass_mock()
     return entity
 
 
 def make_number(coordinator, key):
     desc = next(d for d in NUMBER_DESCRIPTIONS if d.key == key)
-    entity = HondaChargeLimitNumber(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME)
+    entity = HondaChargeLimitNumber(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
     entity.hass = _make_hass_mock()
     return entity
 
 
 def make_sensor(coordinator, key):
     desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == key)
-    entity = HondaSensor(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME)
+    entity = HondaSensor(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
     entity.hass = _make_hass_mock()
     return entity
 
 
 def make_trip_sensor(coordinator, key):
     desc = next(d for d in TRIP_SENSOR_DESCRIPTIONS if d.key == key)
-    entity = HondaTripSensor(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME)
+    entity = HondaTripSensor(coordinator, desc, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
     entity.hass = _make_hass_mock()
     return entity
 
@@ -155,7 +174,10 @@ class TestEntityHelpers:
         old_unsub = MagicMock()
         entity._refresh_unsub = old_unsub
         new_unsub = MagicMock()
-        with patch("custom_components.myhondaplus.entity.async_call_later", return_value=new_unsub) as call_later:
+        with patch(
+            "custom_components.myhondaplus.entity.async_call_later",
+            return_value=new_unsub,
+        ) as call_later:
             entity._schedule_refresh(15)
         old_unsub.assert_called_once()
         call_later.assert_called_once()
@@ -166,7 +188,10 @@ class TestEntityHelpers:
         entity = make_base_entity(mock_coordinator)
         unsub = MagicMock()
         entity._refresh_unsub = unsub
-        with patch("homeassistant.helpers.update_coordinator.CoordinatorEntity.async_will_remove_from_hass", AsyncMock()) as super_remove:
+        with patch(
+            "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_will_remove_from_hass",
+            AsyncMock(),
+        ) as super_remove:
             await entity.async_will_remove_from_hass()
         unsub.assert_called_once()
         assert entity._refresh_unsub is None
@@ -186,10 +211,7 @@ class TestButtonCoverage:
     @pytest.mark.asyncio
     async def test_button_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await button_setup_entry(None, entry, added.extend)
@@ -204,10 +226,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_binary_sensor_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await binary_sensor_setup_entry(None, entry, added.extend)
@@ -217,10 +236,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_device_tracker_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await device_tracker_setup_entry(None, entry, added.extend)
@@ -231,10 +247,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_lock_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await lock_setup_entry(None, entry, added.extend)
@@ -245,10 +258,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_number_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await number_setup_entry(None, entry, added.extend)
@@ -258,10 +268,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_select_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await select_setup_entry(None, entry, added.extend)
@@ -271,14 +278,10 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_sensor_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        trip_coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(
-                coordinator=coordinator,
-                trip_coordinator=trip_coordinator,
-            ),
-            data=dict(MOCK_ENTRY_DATA),
+        trip_coordinator = SimpleNamespace(
+            entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA))
         )
+        entry = _make_entry_with_vehicles(coordinator, trip_coordinator)
         added = []
 
         await sensor_setup_entry(None, entry, added.extend)
@@ -288,10 +291,7 @@ class TestPlatformSetupCoverage:
     @pytest.mark.asyncio
     async def test_switch_platform_setup_entry(self):
         coordinator = SimpleNamespace(entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)))
-        entry = SimpleNamespace(
-            runtime_data=SimpleNamespace(coordinator=coordinator),
-            data=dict(MOCK_ENTRY_DATA),
-        )
+        entry = _make_entry_with_vehicles(coordinator)
         added = []
 
         await switch_setup_entry(None, entry, added.extend)
@@ -313,9 +313,15 @@ class TestNumberCoverage:
                 return False
 
         coordinator = FakeCoordinator()
-        description = next(d for d in NUMBER_DESCRIPTIONS if d.key == "charge_limit_home")
+        description = next(
+            d for d in NUMBER_DESCRIPTIONS if d.key == "charge_limit_home"
+        )
         number = HondaChargeLimitNumber(
-            coordinator, description, MOCK_VIN, MOCK_VEHICLE_NAME,
+            coordinator,
+            description,
+            MOCK_VIN,
+            MOCK_VEHICLE_NAME,
+            "E",
         )
         await number.async_set_native_value(85)
         coordinator.async_set_updated_data.assert_not_called()
@@ -331,7 +337,7 @@ class TestSelectCoverage:
             async_send_command_and_wait=AsyncMock(return_value=True),
             async_set_updated_data=MagicMock(),
         )
-        entity = HondaClimateTempSelect(coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
+        entity = HondaClimateTempSelect(coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = SimpleNamespace(async_create_task=lambda coro: coro.close())
         await entity.async_select_option("cooler")
         args = coordinator.async_send_command_and_wait.call_args[0]
@@ -346,7 +352,9 @@ class TestSelectCoverage:
             async_send_command_and_wait=AsyncMock(return_value=True),
             async_set_updated_data=MagicMock(),
         )
-        entity = HondaClimateDurationSelect(coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
+        entity = HondaClimateDurationSelect(
+            coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E"
+        )
         entity.hass = SimpleNamespace(async_create_task=lambda coro: coro.close())
         await entity.async_select_option("10")
         args = coordinator.async_send_command_and_wait.call_args[0]
@@ -357,14 +365,14 @@ class TestSwitchCoverage:
     @pytest.mark.asyncio
     async def test_climate_switch_no_update_on_failure(self, mock_coordinator):
         mock_coordinator.async_send_command_and_wait.return_value = False
-        entity = HondaClimateSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
+        entity = HondaClimateSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = _make_hass_mock()
         await entity.async_turn_on()
         mock_coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_charge_switch_bool_and_failure_paths(self, mock_coordinator):
-        entity = HondaChargeSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
+        entity = HondaChargeSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = _make_hass_mock()
         mock_coordinator.data["charge_status"] = True
         assert entity.is_on is True
@@ -373,11 +381,13 @@ class TestSwitchCoverage:
         mock_coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_defrost_switch_defaults_and_no_update_on_failure(self, mock_coordinator):
+    async def test_defrost_switch_defaults_and_no_update_on_failure(
+        self, mock_coordinator
+    ):
         mock_coordinator.data["climate_temp"] = "bad"
         mock_coordinator.data["climate_duration"] = 99
         mock_coordinator.async_send_command_and_wait.return_value = False
-        entity = HondaDefrostSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME)
+        entity = HondaDefrostSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = _make_hass_mock()
         await entity.async_turn_off()
         args = mock_coordinator.async_send_command_and_wait.call_args[0]
@@ -386,17 +396,33 @@ class TestSwitchCoverage:
         mock_coordinator.async_set_updated_data.assert_not_called()
 
     def test_auto_refresh_switch(self, mock_coordinator):
-        entry = MagicMock()
-        entry.runtime_data = SimpleNamespace(car_refresh_enabled=False)
-        entity = HondaAutoRefreshSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, entry)
+        vd = VehicleData(
+            coordinator=mock_coordinator,
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+            car_refresh_enabled=False,
+        )
+        entity = HondaAutoRefreshSwitch(
+            mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E", vd
+        )
         entity.async_write_ha_state = MagicMock()
         assert entity.is_on is False
 
     @pytest.mark.asyncio
     async def test_auto_refresh_switch_toggle(self, mock_coordinator):
-        entry = MagicMock()
-        entry.runtime_data = SimpleNamespace(car_refresh_enabled=False)
-        entity = HondaAutoRefreshSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, entry)
+        vd = VehicleData(
+            coordinator=mock_coordinator,
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+            car_refresh_enabled=False,
+        )
+        entity = HondaAutoRefreshSwitch(
+            mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E", vd
+        )
         entity.async_write_ha_state = MagicMock()
         await entity.async_turn_on()
         assert entity.is_on is True
@@ -425,7 +451,10 @@ class TestSensorCoverage:
     def test_trip_sensor_consumption_and_resolve_unit(self, mock_trip_coordinator):
         entity = make_trip_sensor(mock_trip_coordinator, "total_distance")
         assert entity.native_unit_of_measurement == "km"
-        mock_trip_coordinator.data = {"avg_consumption": 12.3, "consumption_unit": "kWh/100km"}
+        mock_trip_coordinator.data = {
+            "avg_consumption": 12.3,
+            "consumption_unit": "kWh/100km",
+        }
         entity = make_trip_sensor(mock_trip_coordinator, "avg_consumption")
         assert entity.native_unit_of_measurement == "kWh/100km"
 
@@ -435,7 +464,9 @@ class TestCoordinatorCoverage:
     async def test_send_command_and_wait_false_command_id(self):
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.async_send_command = AsyncMock(return_value="")
-        result = await HondaDataUpdateCoordinator.async_send_command_and_wait(coord, MagicMock())
+        result = await HondaDataUpdateCoordinator.async_send_command_and_wait(
+            coord, MagicMock()
+        )
         assert result is False
 
     @pytest.mark.asyncio
@@ -447,12 +478,17 @@ class TestCoordinatorCoverage:
         coord._vehicle_name = MOCK_VEHICLE_NAME
         coord.hass.async_add_executor_job = AsyncMock(
             return_value=SimpleNamespace(
-                success=False, status="timeout", timed_out=True, reason=None,
+                success=False,
+                status="timeout",
+                timed_out=True,
+                reason=None,
             ),
         )
         with patch("custom_components.myhondaplus.coordinator.LOGGER") as logger:
             with patch("custom_components.myhondaplus.coordinator.pn_async_create"):
-                result = await HondaDataUpdateCoordinator.async_send_command_and_wait(coord, MagicMock())
+                result = await HondaDataUpdateCoordinator.async_send_command_and_wait(
+                    coord, MagicMock()
+                )
         assert result is False
         logger.warning.assert_called_once()
 
@@ -465,12 +501,19 @@ class TestCoordinatorCoverage:
         coord._vehicle_name = MOCK_VEHICLE_NAME
         coord.hass.async_add_executor_job = AsyncMock(
             return_value=SimpleNamespace(
-                success=False, status="timeout", timed_out=True, reason=None,
+                success=False,
+                status="timeout",
+                timed_out=True,
+                reason=None,
             ),
         )
-        with patch("custom_components.myhondaplus.coordinator.pn_async_create") as pn_create:
+        with patch(
+            "custom_components.myhondaplus.coordinator.pn_async_create"
+        ) as pn_create:
             result = await HondaDataUpdateCoordinator.async_send_command_and_wait(
-                coord, MagicMock(), notify_on_timeout=False,
+                coord,
+                MagicMock(),
+                notify_on_timeout=False,
             )
         assert result is False
         pn_create.assert_not_called()
@@ -483,11 +526,13 @@ class TestCoordinatorCoverage:
         coord.api = MagicMock()
         coord._persist_tokens_if_changed = MagicMock()
         coord.async_send_command = AsyncMock(return_value="cmd")
-        coord.hass.async_add_executor_job = AsyncMock(side_effect=HondaAPIError(500, "boom"))
+        coord.hass.async_add_executor_job = AsyncMock(
+            side_effect=HondaAPIError(500, "boom")
+        )
         with pytest.raises(HomeAssistantError):
             await HondaDataUpdateCoordinator.async_refresh_location(coord)
 
-    def test_apply_tokens_and_persist_tokens(self):
+    def test_persist_tokens(self):
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.entry = MagicMock()
         coord.entry.data = dict(MOCK_ENTRY_DATA)
@@ -497,8 +542,6 @@ class TestCoordinatorCoverage:
             access_token="new-access",
             refresh_token="new-refresh",
         )
-        HondaDataUpdateCoordinator._apply_tokens(coord)
-        coord.api.set_tokens.assert_called_once()
         HondaDataUpdateCoordinator._persist_tokens_if_changed(coord)
         coord.hass.config_entries.async_update_entry.assert_called_once()
 
@@ -506,12 +549,27 @@ class TestCoordinatorCoverage:
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.vin = MOCK_VIN
         coord.api = MagicMock()
-        with patch("custom_components.myhondaplus.coordinator.parse_ev_status", return_value={"x": 1}), \
-             patch("custom_components.myhondaplus.coordinator.parse_charge_schedule", return_value=["a"]), \
-             patch("custom_components.myhondaplus.coordinator.parse_climate_schedule", return_value=["b"]):
+        with (
+            patch(
+                "custom_components.myhondaplus.coordinator.parse_ev_status",
+                return_value={"x": 1},
+            ),
+            patch(
+                "custom_components.myhondaplus.coordinator.parse_charge_schedule",
+                return_value=["a"],
+            ),
+            patch(
+                "custom_components.myhondaplus.coordinator.parse_climate_schedule",
+                return_value=["b"],
+            ),
+        ):
             coord.api.get_dashboard_cached.return_value = {"dash": 1}
             coord.api.refresh_dashboard.return_value = SimpleNamespace(success=True)
-            assert HondaDataUpdateCoordinator._fetch_data(coord) == {"x": 1, "charge_schedule": ["a"], "climate_schedule": ["b"]}
+            assert HondaDataUpdateCoordinator._fetch_data(coord) == {
+                "x": 1,
+                "charge_schedule": ["a"],
+                "climate_schedule": ["b"],
+            }
             assert HondaDataUpdateCoordinator._refresh_from_car(coord).success is True
 
     def test_trip_fetch_data_uses_main_coordinator_distance(self):
@@ -520,7 +578,10 @@ class TestCoordinatorCoverage:
         coord.api = MagicMock()
         coord._fuel_type = "E"
         coord._main_coordinator = MagicMock(data={"distance_unit": "miles"})
-        with patch("custom_components.myhondaplus.coordinator.compute_trip_stats", return_value={"ok": True}) as compute:
+        with patch(
+            "custom_components.myhondaplus.coordinator.compute_trip_stats",
+            return_value={"ok": True},
+        ) as compute:
             coord.api.get_all_trips.return_value = []
             result = HondaTripCoordinator._fetch_data(coord)
         assert result == {"ok": True}
@@ -532,17 +593,29 @@ class TestSchedulerCoverage:
         hass = MagicMock()
         entry = MagicMock()
         entry.options = {"car_refresh_interval": 0}
-        entry.runtime_data = SimpleNamespace(coordinator=MagicMock(), car_refresh_enabled=True, car_refresh_unsub=None)
-        _schedule_car_refresh(hass, entry)
-        assert entry.runtime_data.car_refresh_unsub is None
+        vd = VehicleData(
+            coordinator=MagicMock(),
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+        )
+        _schedule_car_refresh(hass, entry, vd)
+        assert vd.car_refresh_unsub is None
 
     def test_schedule_location_refresh_disabled(self):
         hass = MagicMock()
         entry = MagicMock()
         entry.options = {"location_refresh_interval": 0}
-        entry.runtime_data = SimpleNamespace(coordinator=MagicMock(), location_refresh_unsub=None)
-        _schedule_location_refresh(hass, entry)
-        assert entry.runtime_data.location_refresh_unsub is None
+        vd = VehicleData(
+            coordinator=MagicMock(),
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+        )
+        _schedule_location_refresh(hass, entry, vd)
+        assert vd.location_refresh_unsub is None
 
     @pytest.mark.asyncio
     async def test_async_unload_entry_with_unsubs(self):
@@ -550,10 +623,19 @@ class TestSchedulerCoverage:
         hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
         car_unsub = MagicMock()
         loc_unsub = MagicMock()
-        entry = MagicMock()
-        entry.runtime_data = SimpleNamespace(
+        vd = VehicleData(
+            coordinator=MagicMock(),
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
             car_refresh_unsub=car_unsub,
             location_refresh_unsub=loc_unsub,
+        )
+        entry = MagicMock()
+        entry.runtime_data = SimpleNamespace(
+            vehicles={MOCK_VIN: vd},
+            api=MagicMock(),
         )
         assert await async_unload_entry(hass, entry) is True
         car_unsub.assert_called_once()

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity import EntityDescription
 from pymyhondaplus.api import HondaAPIError
 
 from custom_components.myhondaplus import (
+    _cleanup_removed_vehicles,
     _schedule_car_refresh,
     _schedule_location_refresh,
     _validate_days,
@@ -617,6 +618,42 @@ class TestSchedulerCoverage:
         _schedule_location_refresh(hass, entry, vd)
         assert vd.location_refresh_unsub is None
 
+    def test_schedule_car_refresh_enabled(self):
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.options = {"car_refresh_interval": 3600}
+        vd = VehicleData(
+            coordinator=MagicMock(),
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+        )
+        with patch(
+            "custom_components.myhondaplus.async_call_later", return_value=MagicMock()
+        ) as call_later:
+            _schedule_car_refresh(hass, entry, vd)
+        call_later.assert_called_once()
+        assert vd.car_refresh_unsub is not None
+
+    def test_schedule_location_refresh_enabled(self):
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.options = {"location_refresh_interval": 3600}
+        vd = VehicleData(
+            coordinator=MagicMock(),
+            trip_coordinator=MagicMock(),
+            vin=MOCK_VIN,
+            vehicle_name=MOCK_VEHICLE_NAME,
+            fuel_type="E",
+        )
+        with patch(
+            "custom_components.myhondaplus.async_call_later", return_value=MagicMock()
+        ) as call_later:
+            _schedule_location_refresh(hass, entry, vd)
+        call_later.assert_called_once()
+        assert vd.location_refresh_unsub is not None
+
     @pytest.mark.asyncio
     async def test_async_unload_entry_with_unsubs(self):
         hass = MagicMock()
@@ -640,3 +677,81 @@ class TestSchedulerCoverage:
         assert await async_unload_entry(hass, entry) is True
         car_unsub.assert_called_once()
         loc_unsub.assert_called_once()
+
+
+class TestCleanupRemovedVehicles:
+    def test_removes_device_for_missing_vin(self):
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "entry_1"
+        device = MagicMock()
+        device.identifiers = {("myhondaplus", "OLD_VIN")}
+        device.id = "device_old"
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value = MagicMock()
+            mock_dr.async_entries_for_config_entry.return_value = [device]
+            _cleanup_removed_vehicles(hass, entry, {"CURRENT_VIN"})
+            mock_dr.async_get.return_value.async_remove_device.assert_called_once_with(
+                "device_old"
+            )
+
+    def test_keeps_device_for_active_vin(self):
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "entry_1"
+        device = MagicMock()
+        device.identifiers = {("myhondaplus", MOCK_VIN)}
+        device.id = "device_1"
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value = MagicMock()
+            mock_dr.async_entries_for_config_entry.return_value = [device]
+            _cleanup_removed_vehicles(hass, entry, {MOCK_VIN})
+            mock_dr.async_get.return_value.async_remove_device.assert_not_called()
+
+
+class TestGetCoordinatorEdgeCases:
+    def test_device_without_domain_identifier(self):
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.myhondaplus import ATTR_DEVICE, _get_coordinator
+
+        hass = MagicMock()
+        device = MagicMock()
+        device.identifiers = {("other_domain", "some_id")}
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value.async_get.return_value = device
+            with pytest.raises(ServiceValidationError) as exc_info:
+                _get_coordinator(hass, MagicMock(data={ATTR_DEVICE: "dev1"}))
+        assert exc_info.value.translation_key == "device_not_found"
+
+    def test_device_with_no_loaded_entry(self, mock_runtime_data):
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.myhondaplus import ATTR_DEVICE, _get_coordinator
+
+        hass = MagicMock()
+        device = MagicMock()
+        device.identifiers = {("myhondaplus", MOCK_VIN)}
+        device.config_entries = {"entry_1"}
+        # Entry exists but not loaded
+        entry = MagicMock()
+        entry.domain = "myhondaplus"
+        entry.state = "not_loaded"
+        hass.config_entries.async_get_entry.return_value = entry
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value.async_get.return_value = device
+            with pytest.raises(ServiceValidationError) as exc_info:
+                _get_coordinator(hass, MagicMock(data={ATTR_DEVICE: "dev1"}))
+        assert exc_info.value.translation_key == "device_not_found"
+
+
+class TestDefrostSwitchSuccess:
+    @pytest.mark.asyncio
+    async def test_defrost_turn_on_updates_data(self, mock_coordinator):
+        mock_coordinator.async_send_command_and_wait.return_value = True
+        entity = HondaDefrostSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
+        entity.hass = _make_hass_mock()
+        await entity.async_turn_on()
+        mock_coordinator.async_set_updated_data.assert_called_once()
+        updated = mock_coordinator.async_set_updated_data.call_args[0][0]
+        assert updated["climate_defrost"] is True

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,7 +11,7 @@ import voluptuous as vol
 from homeassistant.const import PERCENTAGE
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
-from pymyhondaplus.api import HondaAPIError
+from pymyhondaplus.api import EVStatus, HondaAPIError
 
 from custom_components.myhondaplus import (
     _cleanup_removed_vehicles,
@@ -31,6 +32,7 @@ from custom_components.myhondaplus.button import (
     async_setup_entry as button_setup_entry,
 )
 from custom_components.myhondaplus.coordinator import (
+    DashboardData,
     HondaDataUpdateCoordinator,
     HondaTripCoordinator,
 )
@@ -305,7 +307,7 @@ class TestNumberCoverage:
     async def test_set_limit_no_update_on_failure(self):
         class FakeCoordinator:
             def __init__(self) -> None:
-                self.data = dict(MOCK_DASHBOARD_DATA)
+                self.data = replace(MOCK_DASHBOARD_DATA)
                 self.api = SimpleNamespace(set_charge_limit=MagicMock())
                 self.entry = SimpleNamespace(data=dict(MOCK_ENTRY_DATA))
                 self.async_set_updated_data = MagicMock()
@@ -332,7 +334,7 @@ class TestSelectCoverage:
     @pytest.mark.asyncio
     async def test_temp_select_uses_default_duration_on_invalid_value(self):
         coordinator = SimpleNamespace(
-            data={**MOCK_DASHBOARD_DATA, "climate_duration": 99},
+            data=replace(MOCK_DASHBOARD_DATA, climate_duration=99),
             api=SimpleNamespace(set_climate_settings=MagicMock()),
             entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)),
             async_send_command_and_wait=AsyncMock(return_value=True),
@@ -347,7 +349,7 @@ class TestSelectCoverage:
     @pytest.mark.asyncio
     async def test_duration_select_uses_default_temp_on_invalid_value(self):
         coordinator = SimpleNamespace(
-            data={**MOCK_DASHBOARD_DATA, "climate_temp": "weird"},
+            data=replace(MOCK_DASHBOARD_DATA, climate_temp="weird"),
             api=SimpleNamespace(set_climate_settings=MagicMock()),
             entry=SimpleNamespace(data=dict(MOCK_ENTRY_DATA)),
             async_send_command_and_wait=AsyncMock(return_value=True),
@@ -375,7 +377,7 @@ class TestSwitchCoverage:
     async def test_charge_switch_bool_and_failure_paths(self, mock_coordinator):
         entity = HondaChargeSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = _make_hass_mock()
-        mock_coordinator.data["charge_status"] = True
+        mock_coordinator.data.charge_status = True
         assert entity.is_on is True
         mock_coordinator.async_send_command_and_wait.return_value = False
         await entity.async_turn_off()
@@ -385,8 +387,8 @@ class TestSwitchCoverage:
     async def test_defrost_switch_defaults_and_no_update_on_failure(
         self, mock_coordinator
     ):
-        mock_coordinator.data["climate_temp"] = "bad"
-        mock_coordinator.data["climate_duration"] = 99
+        mock_coordinator.data.climate_temp = "bad"
+        mock_coordinator.data.climate_duration = 99
         mock_coordinator.async_send_command_and_wait.return_value = False
         entity = HondaDefrostSwitch(mock_coordinator, MOCK_VIN, MOCK_VEHICLE_NAME, "E")
         entity.hass = _make_hass_mock()
@@ -440,11 +442,11 @@ class TestSensorCoverage:
     def test_sensor_timestamp_parsing(self, mock_coordinator):
         entity = make_sensor(mock_coordinator, "timestamp")
         assert entity.native_value.year == 2026
-        mock_coordinator.data["timestamp"] = "bad"
+        mock_coordinator.data.timestamp = "bad"
         assert entity.native_value is None
 
     def test_sensor_schedule_non_list(self, mock_coordinator):
-        mock_coordinator.data["charge_schedule"] = "bad"
+        mock_coordinator.data.charge_schedule = "bad"
         entity = make_sensor(mock_coordinator, "charge_schedule")
         assert entity.native_value == 0
         assert entity.extra_state_attributes is None
@@ -550,10 +552,11 @@ class TestCoordinatorCoverage:
         coord = HondaDataUpdateCoordinator.__new__(HondaDataUpdateCoordinator)
         coord.vin = MOCK_VIN
         coord.api = MagicMock()
+        mock_ev = EVStatus(battery_level=42)
         with (
             patch(
                 "custom_components.myhondaplus.coordinator.parse_ev_status",
-                return_value={"x": 1},
+                return_value=mock_ev,
             ),
             patch(
                 "custom_components.myhondaplus.coordinator.parse_charge_schedule",
@@ -566,11 +569,11 @@ class TestCoordinatorCoverage:
         ):
             coord.api.get_dashboard_cached.return_value = {"dash": 1}
             coord.api.refresh_dashboard.return_value = SimpleNamespace(success=True)
-            assert HondaDataUpdateCoordinator._fetch_data(coord) == {
-                "x": 1,
-                "charge_schedule": ["a"],
-                "climate_schedule": ["b"],
-            }
+            result = HondaDataUpdateCoordinator._fetch_data(coord)
+            assert isinstance(result, DashboardData)
+            assert result.battery_level == 42
+            assert result.charge_schedule == ["a"]
+            assert result.climate_schedule == ["b"]
             assert HondaDataUpdateCoordinator._refresh_from_car(coord).success is True
 
     def test_trip_fetch_data_uses_main_coordinator_distance(self):
@@ -578,7 +581,7 @@ class TestCoordinatorCoverage:
         coord.vin = MOCK_VIN
         coord.api = MagicMock()
         coord._fuel_type = "E"
-        coord._main_coordinator = MagicMock(data={"distance_unit": "miles"})
+        coord._main_coordinator = MagicMock(data=replace(MOCK_DASHBOARD_DATA, distance_unit="miles"))
         with patch(
             "custom_components.myhondaplus.coordinator.compute_trip_stats",
             return_value={"ok": True},

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,11 +8,12 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.myhondaplus import (
-    ATTR_CONFIG_ENTRY,
+    ATTR_DEVICE,
     SERVICE_CLIMATE_ON,
     SERVICE_CLIMATE_ON_SCHEMA,
     SERVICE_SET_CHARGE_SCHEDULE,
     SERVICE_SET_CLIMATE_SCHEDULE,
+    _consolidate_duplicate_entries,
     _get_coordinator,
     _register_services,
     async_migrate_entry,
@@ -21,11 +22,19 @@ from custom_components.myhondaplus import (
     async_setup_entry,
 )
 from custom_components.myhondaplus.const import (
+    CONF_ACCESS_TOKEN,
     CONF_CAR_REFRESH_INTERVAL,
+    CONF_FUEL_TYPE,
     CONF_LOCATION_REFRESH_INTERVAL,
+    CONF_REFRESH_TOKEN,
     CONF_SCAN_INTERVAL,
+    CONF_USER_ID,
+    CONF_VEHICLE_NAME,
+    CONF_VEHICLES,
+    CONF_VIN,
     DOMAIN,
 )
+from tests.conftest import MOCK_V2_ENTRY_DATA, MOCK_VIN
 
 
 @pytest.fixture
@@ -37,77 +46,37 @@ def mock_hass_with_services():
     return hass
 
 
-@pytest.fixture
-def mock_entry_with_coordinator(mock_coordinator):
-    """Return a mocked config entry with runtime_data."""
-    entry = MagicMock()
-    entry.runtime_data = MagicMock()
-    entry.runtime_data.coordinator = mock_coordinator
-    entry.runtime_data.trip_coordinator = MagicMock()
-    entry.runtime_data.car_refresh_unsub = None
-    entry.runtime_data.car_refresh_enabled = True
-    return entry
-
-
 class TestGetCoordinator:
-    def test_returns_coordinator(self, mock_coordinator):
+    def test_returns_coordinator_via_device(self, mock_coordinator, mock_runtime_data):
         hass = MagicMock()
+        device = MagicMock()
+        device.identifiers = {(DOMAIN, MOCK_VIN)}
         entry = MagicMock()
-        entry.runtime_data = MagicMock()
-        entry.runtime_data.coordinator = mock_coordinator
-        entry.entry_id = "entry_1"
         entry.domain = DOMAIN
         entry.state = ConfigEntryState.LOADED
-        hass.config_entries.async_get_entry.return_value = entry
-        assert _get_coordinator(hass, MagicMock(service="test", data={ATTR_CONFIG_ENTRY: "entry_1"})) is mock_coordinator
-
-    def test_raises_when_no_entries(self):
-        hass = MagicMock()
-        hass.config_entries.async_get_entry.return_value = None
-        with pytest.raises(ServiceValidationError) as exc_info:
-            _get_coordinator(hass, MagicMock(service="test", data={ATTR_CONFIG_ENTRY: "entry_1"}))
-        assert exc_info.value.translation_key == "config_entry_not_found"
-
-    def test_raises_when_unloaded(self, mock_coordinator):
-        hass = MagicMock()
-        entry = MagicMock()
-        entry.entry_id = "entry_1"
-        entry.domain = DOMAIN
-        entry.state = "not_loaded"
-        entry.runtime_data = MagicMock()
-        entry.runtime_data.coordinator = mock_coordinator
+        entry.runtime_data = mock_runtime_data
+        device.config_entries = {"entry_1"}
         hass.config_entries.async_get_entry.return_value = entry
 
-        with pytest.raises(ServiceValidationError) as exc_info:
-            _get_coordinator(hass, MagicMock(service="test", data={ATTR_CONFIG_ENTRY: "entry_1"}))
-        assert exc_info.value.translation_key == "config_entry_not_loaded"
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value.async_get.return_value = device
+            result = _get_coordinator(hass, MagicMock(data={ATTR_DEVICE: "device_1"}))
 
-    def test_raises_when_wrong_domain(self, mock_coordinator):
+        assert result is mock_coordinator
+
+    def test_raises_when_no_device(self):
         hass = MagicMock()
-        entry = MagicMock()
-        entry.entry_id = "entry_1"
-        entry.domain = "wrong_domain"
-        entry.state = ConfigEntryState.LOADED
-        entry.runtime_data = MagicMock()
-        entry.runtime_data.coordinator = mock_coordinator
-        hass.config_entries.async_get_entry.return_value = entry
-
         with pytest.raises(ServiceValidationError) as exc_info:
-            _get_coordinator(hass, MagicMock(service="test", data={ATTR_CONFIG_ENTRY: "entry_1"}))
-        assert exc_info.value.translation_key == "config_entry_not_found"
+            _get_coordinator(hass, MagicMock(data={}))
+        assert exc_info.value.translation_key == "device_required"
 
-    def test_raises_when_runtime_data_missing(self):
+    def test_raises_when_device_not_found(self):
         hass = MagicMock()
-        entry = MagicMock()
-        entry.entry_id = "entry_1"
-        entry.domain = DOMAIN
-        entry.state = ConfigEntryState.LOADED
-        entry.runtime_data = None
-        hass.config_entries.async_get_entry.return_value = entry
-
-        with pytest.raises(ServiceValidationError) as exc_info:
-            _get_coordinator(hass, MagicMock(service="test", data={ATTR_CONFIG_ENTRY: "entry_1"}))
-        assert exc_info.value.translation_key == "config_entry_no_data"
+        with patch("custom_components.myhondaplus.dr") as mock_dr:
+            mock_dr.async_get.return_value.async_get.return_value = None
+            with pytest.raises(ServiceValidationError) as exc_info:
+                _get_coordinator(hass, MagicMock(data={ATTR_DEVICE: "nonexistent"}))
+        assert exc_info.value.translation_key == "device_not_found"
 
 
 class TestRegisterServices:
@@ -121,7 +90,8 @@ class TestRegisterServices:
         assert mock_hass_with_services.services.async_register.call_count == 3
 
         registered = {
-            call[0][1] for call in mock_hass_with_services.services.async_register.call_args_list
+            call[0][1]
+            for call in mock_hass_with_services.services.async_register.call_args_list
         }
         assert registered == {
             SERVICE_SET_CHARGE_SCHEDULE,
@@ -147,45 +117,62 @@ class TestMigration:
             CONF_SCAN_INTERVAL: 300,
             CONF_CAR_REFRESH_INTERVAL: 7200,
             CONF_LOCATION_REFRESH_INTERVAL: 1800,
+            "email": "test@example.com",
             "vin": "VIN123",
+            "vehicle_name": "Car",
+            "fuel_type": "E",
         }
         entry.options = {}
+        entry.unique_id = "VIN123"
+
+        # Simulate version advancing after each async_update_entry
+        def advance_version(*args, **kwargs):
+            entry.version = kwargs.get("version", entry.version)
+
+        mock_hass.config_entries.async_update_entry.side_effect = advance_version
 
         assert await async_migrate_entry(mock_hass, entry) is True
 
-        mock_hass.config_entries.async_update_entry.assert_called_once()
-        kwargs = mock_hass.config_entries.async_update_entry.call_args.kwargs
-        assert kwargs["data"] == {"vin": "VIN123"}
-        assert kwargs["options"] == {
-            CONF_SCAN_INTERVAL: 300,
-            CONF_CAR_REFRESH_INTERVAL: 7200,
-            CONF_LOCATION_REFRESH_INTERVAL: 1800,
-        }
-        assert kwargs["version"] == 2
+        # v1→v2 is the first call, v2→v3 is the second
+        assert mock_hass.config_entries.async_update_entry.call_count == 2
+        first_call = mock_hass.config_entries.async_update_entry.call_args_list[
+            0
+        ].kwargs
+        assert first_call["version"] == 2
+        second_call = mock_hass.config_entries.async_update_entry.call_args_list[
+            1
+        ].kwargs
+        assert second_call["version"] == 3
+        assert CONF_VEHICLES in second_call["data"]
 
     @pytest.mark.asyncio
-    async def test_migrate_v1_preserves_existing_options(self, mock_hass):
-        entry = MagicMock()
-        entry.version = 1
-        entry.data = {
-            CONF_SCAN_INTERVAL: 300,
-            CONF_CAR_REFRESH_INTERVAL: 7200,
-        }
-        entry.options = {CONF_SCAN_INTERVAL: 600}
-
-        assert await async_migrate_entry(mock_hass, entry) is True
-
-        kwargs = mock_hass.config_entries.async_update_entry.call_args.kwargs
-        assert kwargs["data"] == {}
-        assert kwargs["options"] == {
-            CONF_SCAN_INTERVAL: 600,
-            CONF_CAR_REFRESH_INTERVAL: 7200,
-        }
-
-    @pytest.mark.asyncio
-    async def test_migrate_current_version_noop(self, mock_hass):
+    async def test_migrate_v2_wraps_vehicle_in_list(self, mock_hass):
         entry = MagicMock()
         entry.version = 2
+        entry.data = dict(MOCK_V2_ENTRY_DATA)
+        entry.options = {}
+        entry.unique_id = MOCK_VIN
+
+        assert await async_migrate_entry(mock_hass, entry) is True
+
+        kwargs = mock_hass.config_entries.async_update_entry.call_args.kwargs
+        assert CONF_VIN not in kwargs["data"]
+        assert CONF_VEHICLE_NAME not in kwargs["data"]
+        assert CONF_FUEL_TYPE not in kwargs["data"]
+        assert kwargs["data"][CONF_VEHICLES] == [
+            {
+                CONF_VIN: MOCK_VIN,
+                CONF_VEHICLE_NAME: "Honda e Test",
+                CONF_FUEL_TYPE: "E",
+            }
+        ]
+        assert kwargs["unique_id"] == "test@example.com"
+        assert kwargs["version"] == 3
+
+    @pytest.mark.asyncio
+    async def test_migrate_v3_noop(self, mock_hass):
+        entry = MagicMock()
+        entry.version = 3
         entry.data = {}
         entry.options = {}
 
@@ -193,31 +180,100 @@ class TestMigration:
         mock_hass.config_entries.async_update_entry.assert_not_called()
 
 
+class TestConsolidation:
+    def test_merges_duplicate_entries(self, mock_hass):
+        """Two entries for the same email get merged."""
+        main_entry = MagicMock()
+        main_entry.entry_id = "main"
+        main_entry.data = {
+            "email": "test@example.com",
+            CONF_VEHICLES: [
+                {CONF_VIN: "VIN1", CONF_VEHICLE_NAME: "Car 1", CONF_FUEL_TYPE: "E"}
+            ],
+        }
+
+        dup_entry = MagicMock()
+        dup_entry.entry_id = "dup"
+        dup_entry.data = {
+            "email": "test@example.com",
+            CONF_VEHICLES: [
+                {CONF_VIN: "VIN2", CONF_VEHICLE_NAME: "Car 2", CONF_FUEL_TYPE: "H"}
+            ],
+        }
+
+        mock_hass.config_entries.async_entries.return_value = [main_entry, dup_entry]
+
+        _consolidate_duplicate_entries(mock_hass, main_entry)
+
+        # Should merge VIN2 into main entry
+        update_call = mock_hass.config_entries.async_update_entry.call_args
+        new_vehicles = update_call.kwargs["data"][CONF_VEHICLES]
+        assert len(new_vehicles) == 2
+        assert {v[CONF_VIN] for v in new_vehicles} == {"VIN1", "VIN2"}
+
+        # Should remove duplicate
+        mock_hass.async_create_task.assert_called_once()
+
+    def test_no_duplicates_noop(self, mock_hass):
+        """Single entry does nothing."""
+        entry = MagicMock()
+        entry.entry_id = "only"
+        entry.data = {
+            "email": "test@example.com",
+            CONF_VEHICLES: [{CONF_VIN: "VIN1"}],
+        }
+        mock_hass.config_entries.async_entries.return_value = [entry]
+
+        _consolidate_duplicate_entries(mock_hass, entry)
+
+        mock_hass.config_entries.async_update_entry.assert_not_called()
+
+
 class TestSetupEntry:
     @pytest.mark.asyncio
-    async def test_setup_entry_registers_update_listener(self, mock_hass, mock_entry_with_coordinator):
-        mock_entry_with_coordinator.add_update_listener = MagicMock(return_value="listener")
-        mock_entry_with_coordinator.async_on_unload = MagicMock()
-        mock_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    async def test_setup_entry_registers_update_listener(self, mock_hass):
+        entry = MagicMock()
+        entry.data = {
+            "email": "test@example.com",
+            CONF_ACCESS_TOKEN: "tok",
+            CONF_REFRESH_TOKEN: "ref",
+            CONF_USER_ID: "uid",
+            CONF_VEHICLES: [
+                {CONF_VIN: MOCK_VIN, CONF_VEHICLE_NAME: "Car", CONF_FUEL_TYPE: "E"}
+            ],
+        }
+        entry.options = {}
+        entry.entry_id = "test"
+        entry.add_update_listener = MagicMock(return_value="listener")
+        entry.async_on_unload = MagicMock()
+        mock_hass.config_entries.async_forward_entry_setups = AsyncMock(
+            return_value=True
+        )
+        mock_hass.config_entries.async_entries.return_value = [entry]
 
-        with patch("custom_components.myhondaplus.HondaDataUpdateCoordinator") as coordinator_cls, \
-             patch("custom_components.myhondaplus.HondaTripCoordinator") as trip_cls, \
-             patch("custom_components.myhondaplus._schedule_car_refresh"), \
-            patch("custom_components.myhondaplus._schedule_location_refresh"):
-            coordinator = MagicMock()
-            coordinator.async_config_entry_first_refresh = AsyncMock()
-            coordinator.api = MagicMock()
-            coordinator._persist_tokens_if_changed = MagicMock()
-            coordinator_cls.return_value = coordinator
-
+        with (
+            patch("custom_components.myhondaplus.HondaAPI") as api_cls,
+            patch(
+                "custom_components.myhondaplus.HondaDataUpdateCoordinator"
+            ) as coord_cls,
+            patch("custom_components.myhondaplus.HondaTripCoordinator") as trip_cls,
+            patch("custom_components.myhondaplus._schedule_car_refresh"),
+            patch("custom_components.myhondaplus._schedule_location_refresh"),
+            patch("custom_components.myhondaplus._cleanup_removed_vehicles"),
+        ):
+            api_cls.return_value = MagicMock()
+            coord = MagicMock()
+            coord.async_config_entry_first_refresh = AsyncMock()
+            coord._persist_tokens_if_changed = MagicMock()
+            coord_cls.return_value = coord
             trip = MagicMock()
             trip.async_config_entry_first_refresh = AsyncMock()
             trip_cls.return_value = trip
 
-            assert await async_setup_entry(mock_hass, mock_entry_with_coordinator) is True
+            assert await async_setup_entry(mock_hass, entry) is True
 
-        mock_entry_with_coordinator.add_update_listener.assert_called_once()
-        mock_entry_with_coordinator.async_on_unload.assert_called_once_with("listener")
+        entry.add_update_listener.assert_called_once()
+        entry.async_on_unload.assert_called_once_with("listener")
 
     @pytest.mark.asyncio
     async def test_reload_entry_uses_config_entries_reload(self, mock_hass):
@@ -234,193 +290,240 @@ class TestChargeScheduleSchema:
     def test_valid_charge_rule(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
-        result = SERVICE_CHARGE_SCHEDULE_SCHEMA({
-            "config_entry": "entry_1",
-            "rules": [{
-                "days": "mon,tue,wed",
-                "location": "home",
-                "start_time": "22:00",
-                "end_time": "06:00",
-            }],
-        })
-        assert result["config_entry"] == "entry_1"
+        result = SERVICE_CHARGE_SCHEDULE_SCHEMA(
+            {
+                "device": "device_1",
+                "rules": [
+                    {
+                        "days": "mon,tue,wed",
+                        "location": "home",
+                        "start_time": "22:00",
+                        "end_time": "06:00",
+                    }
+                ],
+            }
+        )
+        assert result["device"] == "device_1"
         assert result["rules"][0]["enabled"] is True
 
     def test_missing_required_field(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [{"days": "mon", "start_time": "22:00"}],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "rules": [{"days": "mon", "start_time": "22:00"}],
+                }
+            )
 
     def test_invalid_location(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [{
-                    "days": "mon",
-                    "location": "work",
-                    "start_time": "22:00",
-                    "end_time": "06:00",
-                }],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {
+                            "days": "mon",
+                            "location": "work",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        }
+                    ],
+                }
+            )
 
     def test_invalid_day_token(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [{
-                    "days": "mon,holiday",
-                    "location": "home",
-                    "start_time": "22:00",
-                    "end_time": "06:00",
-                }],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {
+                            "days": "mon,holiday",
+                            "location": "home",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        }
+                    ],
+                }
+            )
 
     def test_duplicate_days(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [{
-                    "days": "mon,mon",
-                    "location": "home",
-                    "start_time": "22:00",
-                    "end_time": "06:00",
-                }],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {
+                            "days": "mon,mon",
+                            "location": "home",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        }
+                    ],
+                }
+            )
 
     def test_invalid_time(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [{
-                    "days": "mon",
-                    "location": "home",
-                    "start_time": "25:00",
-                    "end_time": "06:00",
-                }],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {
+                            "days": "mon",
+                            "location": "home",
+                            "start_time": "25:00",
+                            "end_time": "06:00",
+                        }
+                    ],
+                }
+            )
 
     def test_max_two_rules(self):
         from custom_components.myhondaplus import SERVICE_CHARGE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CHARGE_SCHEDULE_SCHEMA({
-                "rules": [
-                    {
-                        "days": "mon",
-                        "location": "home",
-                        "start_time": "22:00",
-                        "end_time": "06:00",
-                    },
-                    {
-                        "days": "tue",
-                        "location": "home",
-                        "start_time": "22:00",
-                        "end_time": "06:00",
-                    },
-                    {
-                        "days": "wed",
-                        "location": "home",
-                        "start_time": "22:00",
-                        "end_time": "06:00",
-                    },
-                ],
-            })
+            SERVICE_CHARGE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {
+                            "days": "mon",
+                            "location": "home",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        },
+                        {
+                            "days": "tue",
+                            "location": "home",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        },
+                        {
+                            "days": "wed",
+                            "location": "home",
+                            "start_time": "22:00",
+                            "end_time": "06:00",
+                        },
+                    ],
+                }
+            )
 
 
 class TestClimateScheduleSchema:
     def test_valid_climate_rule(self):
         from custom_components.myhondaplus import SERVICE_CLIMATE_SCHEDULE_SCHEMA
 
-        result = SERVICE_CLIMATE_SCHEDULE_SCHEMA({
-            "config_entry": "entry_1",
-            "rules": [{"days": "mon,fri", "start_time": "07:00"}],
-        })
-        assert result["config_entry"] == "entry_1"
+        result = SERVICE_CLIMATE_SCHEDULE_SCHEMA(
+            {
+                "device": "device_1",
+                "rules": [{"days": "mon,fri", "start_time": "07:00"}],
+            }
+        )
+        assert result["device"] == "device_1"
         assert result["rules"][0]["enabled"] is True
 
     def test_missing_days(self):
         from custom_components.myhondaplus import SERVICE_CLIMATE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_SCHEDULE_SCHEMA({
-                "rules": [{"start_time": "07:00"}],
-            })
+            SERVICE_CLIMATE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [{"start_time": "07:00"}],
+                }
+            )
 
     def test_invalid_time(self):
         from custom_components.myhondaplus import SERVICE_CLIMATE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_SCHEDULE_SCHEMA({
-                "rules": [{"days": "mon", "start_time": "7:00"}],
-            })
+            SERVICE_CLIMATE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [{"days": "mon", "start_time": "7:00"}],
+                }
+            )
 
     def test_invalid_day_token(self):
         from custom_components.myhondaplus import SERVICE_CLIMATE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_SCHEDULE_SCHEMA({
-                "rules": [{"days": "mon,foo", "start_time": "07:00"}],
-            })
+            SERVICE_CLIMATE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [{"days": "mon,foo", "start_time": "07:00"}],
+                }
+            )
 
     def test_max_seven_rules(self):
         from custom_components.myhondaplus import SERVICE_CLIMATE_SCHEDULE_SCHEMA
 
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_SCHEDULE_SCHEMA({
-                "rules": [
-                    {"days": "mon", "start_time": "07:00"},
-                    {"days": "tue", "start_time": "07:00"},
-                    {"days": "wed", "start_time": "07:00"},
-                    {"days": "thu", "start_time": "07:00"},
-                    {"days": "fri", "start_time": "07:00"},
-                    {"days": "sat", "start_time": "07:00"},
-                    {"days": "sun", "start_time": "07:00"},
-                    {"days": "mon", "start_time": "08:00"},
-                ],
-            })
+            SERVICE_CLIMATE_SCHEDULE_SCHEMA(
+                {
+                    "device": "d1",
+                    "rules": [
+                        {"days": "mon", "start_time": "07:00"},
+                        {"days": "tue", "start_time": "07:00"},
+                        {"days": "wed", "start_time": "07:00"},
+                        {"days": "thu", "start_time": "07:00"},
+                        {"days": "fri", "start_time": "07:00"},
+                        {"days": "sat", "start_time": "07:00"},
+                        {"days": "sun", "start_time": "07:00"},
+                        {"days": "mon", "start_time": "08:00"},
+                    ],
+                }
+            )
 
 
 class TestClimateOnSchema:
     def test_defaults(self):
-        result = SERVICE_CLIMATE_ON_SCHEMA({"config_entry": "entry_1"})
-        assert result["config_entry"] == "entry_1"
+        result = SERVICE_CLIMATE_ON_SCHEMA({"device": "device_1"})
+        assert result["device"] == "device_1"
         assert result["temp"] == "normal"
         assert result["duration"] == 30
         assert result["defrost"] is True
 
     def test_valid_values(self):
-        result = SERVICE_CLIMATE_ON_SCHEMA({
-            "config_entry": "entry_1",
-            "temp": "cooler",
-            "duration": 10,
-            "defrost": False,
-        })
-        assert result["config_entry"] == "entry_1"
+        result = SERVICE_CLIMATE_ON_SCHEMA(
+            {
+                "device": "device_1",
+                "temp": "cooler",
+                "duration": 10,
+                "defrost": False,
+            }
+        )
+        assert result["device"] == "device_1"
         assert result["temp"] == "cooler"
         assert result["duration"] == 10
         assert result["defrost"] is False
 
     def test_valid_string_duration_from_ui(self):
-        result = SERVICE_CLIMATE_ON_SCHEMA({
-            "config_entry": "entry_1",
-            "duration": "20",
-        })
+        result = SERVICE_CLIMATE_ON_SCHEMA(
+            {
+                "device": "device_1",
+                "duration": "20",
+            }
+        )
         assert result["duration"] == 20
 
     def test_invalid_temp(self):
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_ON_SCHEMA({"temp": "freezing"})
+            SERVICE_CLIMATE_ON_SCHEMA({"device": "d1", "temp": "freezing"})
 
     def test_invalid_duration(self):
         with pytest.raises(vol.Invalid):
-            SERVICE_CLIMATE_ON_SCHEMA({"duration": 45})
+            SERVICE_CLIMATE_ON_SCHEMA({"device": "d1", "duration": 45})
 
 
 class TestServiceHandlers:
@@ -433,7 +536,10 @@ class TestServiceHandlers:
             for call in mock_hass_with_services.services.async_register.call_args_list
         }
 
-        with patch("custom_components.myhondaplus._get_coordinator", return_value=mock_coordinator):
+        with patch(
+            "custom_components.myhondaplus._get_coordinator",
+            return_value=mock_coordinator,
+        ):
             call = MagicMock()
             call.data = {"temp": "hotter", "duration": 20, "defrost": False}
             await handlers[SERVICE_CLIMATE_ON](call)
@@ -452,7 +558,9 @@ class TestServiceHandlers:
         assert updated["climate_defrost"] is False
 
     @pytest.mark.asyncio
-    async def test_handle_set_charge_schedule(self, mock_hass_with_services, mock_coordinator):
+    async def test_handle_set_charge_schedule(
+        self, mock_hass_with_services, mock_coordinator
+    ):
         """set_charge_schedule calls API and does optimistic update."""
         _register_services(mock_hass_with_services)
         handlers = {
@@ -460,9 +568,21 @@ class TestServiceHandlers:
             for call in mock_hass_with_services.services.async_register.call_args_list
         }
 
-        with patch("custom_components.myhondaplus._get_coordinator", return_value=mock_coordinator):
+        with patch(
+            "custom_components.myhondaplus._get_coordinator",
+            return_value=mock_coordinator,
+        ):
             call = MagicMock()
-            call.data = {"rules": [{"days": "mon,tue", "location": "home", "start_time": "22:00", "end_time": "06:00"}]}
+            call.data = {
+                "rules": [
+                    {
+                        "days": "mon,tue",
+                        "location": "home",
+                        "start_time": "22:00",
+                        "end_time": "06:00",
+                    }
+                ]
+            }
             await handlers[SERVICE_SET_CHARGE_SCHEDULE](call)
 
         mock_coordinator.async_send_command.assert_awaited_once()
@@ -472,7 +592,9 @@ class TestServiceHandlers:
         assert updated["charge_schedule"][0]["enabled"] is True
 
     @pytest.mark.asyncio
-    async def test_handle_set_climate_schedule(self, mock_hass_with_services, mock_coordinator):
+    async def test_handle_set_climate_schedule(
+        self, mock_hass_with_services, mock_coordinator
+    ):
         """set_climate_schedule calls API and does optimistic update."""
         _register_services(mock_hass_with_services)
         handlers = {
@@ -480,7 +602,10 @@ class TestServiceHandlers:
             for call in mock_hass_with_services.services.async_register.call_args_list
         }
 
-        with patch("custom_components.myhondaplus._get_coordinator", return_value=mock_coordinator):
+        with patch(
+            "custom_components.myhondaplus._get_coordinator",
+            return_value=mock_coordinator,
+        ):
             call = MagicMock()
             call.data = {"rules": [{"days": "mon", "start_time": "07:00"}]}
             await handlers[SERVICE_SET_CLIMATE_SCHEDULE](call)
@@ -490,7 +615,9 @@ class TestServiceHandlers:
 
     @pytest.mark.asyncio
     async def test_handlers_pass_service_call_to_target_resolution(
-        self, mock_hass_with_services, mock_coordinator,
+        self,
+        mock_hass_with_services,
+        mock_coordinator,
     ):
         _register_services(mock_hass_with_services)
         handlers = {
@@ -500,7 +627,6 @@ class TestServiceHandlers:
 
         call = MagicMock()
         call.data = {
-            "entity_id": "sensor.honda_two_battery_level",
             "rules": [{"days": "mon", "start_time": "07:00"}],
         }
         with patch(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -51,7 +51,8 @@ class TestDoorLock:
     async def test_lock(self, door_lock):
         await door_lock.async_lock()
         door_lock.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            door_lock.coordinator.api.remote_lock, MOCK_VIN,
+            door_lock.coordinator.api.remote_lock,
+            MOCK_VIN,
         )
         door_lock.coordinator.async_set_updated_data.assert_called_once()
         data = door_lock.coordinator.async_set_updated_data.call_args[0][0]
@@ -61,7 +62,8 @@ class TestDoorLock:
     async def test_unlock(self, door_lock):
         await door_lock.async_unlock()
         door_lock.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            door_lock.coordinator.api.remote_unlock, MOCK_VIN,
+            door_lock.coordinator.api.remote_unlock,
+            MOCK_VIN,
         )
         door_lock.coordinator.async_set_updated_data.assert_called_once()
         data = door_lock.coordinator.async_set_updated_data.call_args[0][0]

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -20,31 +20,31 @@ def door_lock(mock_coordinator):
 
 class TestDoorLock:
     def test_is_locked_true(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = True
+        door_lock.coordinator.data.doors_locked = True
         assert door_lock.is_locked is True
 
     def test_is_locked_false(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = False
+        door_lock.coordinator.data.doors_locked = False
         assert door_lock.is_locked is False
 
     def test_is_locked_string_locked(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = "locked"
+        door_lock.coordinator.data.doors_locked = "locked"
         assert door_lock.is_locked is True
 
     def test_is_locked_string_true(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = "true"
+        door_lock.coordinator.data.doors_locked = "true"
         assert door_lock.is_locked is True
 
     def test_is_locked_string_unlocked(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = "unlocked"
+        door_lock.coordinator.data.doors_locked = "unlocked"
         assert door_lock.is_locked is False
 
     def test_is_locked_none(self, door_lock):
-        door_lock.coordinator.data["doors_locked"] = None
+        door_lock.coordinator.data.doors_locked = None
         assert door_lock.is_locked is None
 
     def test_is_locked_missing_key(self, door_lock):
-        door_lock.coordinator.data.pop("doors_locked", None)
+        door_lock.coordinator.data.doors_locked = None
         assert door_lock.is_locked is None
 
     @pytest.mark.asyncio

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -44,7 +44,10 @@ class TestChargeLimitNumber:
         number = make_number(mock_coordinator, "charge_limit_home")
         await number.async_set_native_value(85.0)
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            mock_coordinator.api.set_charge_limit, MOCK_VIN, 85, 100,
+            mock_coordinator.api.set_charge_limit,
+            MOCK_VIN,
+            85,
+            100,
         )
         # Confirmed update via async_set_updated_data
         mock_coordinator.async_set_updated_data.assert_called_once()
@@ -63,7 +66,10 @@ class TestChargeLimitNumber:
         number = make_number(mock_coordinator, "charge_limit_away")
         await number.async_set_native_value(95.0)
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            mock_coordinator.api.set_charge_limit, MOCK_VIN, 90, 95,
+            mock_coordinator.api.set_charge_limit,
+            MOCK_VIN,
+            90,
+            95,
         )
         mock_coordinator.async_set_updated_data.assert_called_once()
         data = mock_coordinator.async_set_updated_data.call_args[0][0]
@@ -77,5 +83,8 @@ class TestChargeLimitNumber:
         number = make_number(mock_coordinator, "charge_limit_home")
         await number.async_set_native_value(100.0)
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            mock_coordinator.api.set_charge_limit, MOCK_VIN, 100, 95,
+            mock_coordinator.api.set_charge_limit,
+            MOCK_VIN,
+            100,
+            95,
         )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -78,8 +78,8 @@ class TestChargeLimitNumber:
     @pytest.mark.asyncio
     async def test_set_limit_uses_current_values_for_other(self, mock_coordinator):
         """Setting home should pass the current away value and vice versa."""
-        mock_coordinator.data["charge_limit_home"] = 80
-        mock_coordinator.data["charge_limit_away"] = 95
+        mock_coordinator.data.charge_limit_home = 80
+        mock_coordinator.data.charge_limit_away = 95
         number = make_number(mock_coordinator, "charge_limit_home")
         await number.async_set_native_value(100.0)
         mock_coordinator.async_send_command_and_wait.assert_awaited_once_with(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -31,23 +31,23 @@ class TestClimateTempSelect:
         assert temp_select._attr_options == ["cooler", "normal", "hotter"]
 
     def test_current_option_normal(self, temp_select):
-        temp_select.coordinator.data["climate_temp"] = "normal"
+        temp_select.coordinator.data.climate_temp = "normal"
         assert temp_select.current_option == "normal"
 
     def test_current_option_cooler(self, temp_select):
-        temp_select.coordinator.data["climate_temp"] = "cooler"
+        temp_select.coordinator.data.climate_temp = "cooler"
         assert temp_select.current_option == "cooler"
 
     def test_current_option_hotter(self, temp_select):
-        temp_select.coordinator.data["climate_temp"] = "hotter"
+        temp_select.coordinator.data.climate_temp = "hotter"
         assert temp_select.current_option == "hotter"
 
     def test_current_option_invalid_defaults_normal(self, temp_select):
-        temp_select.coordinator.data["climate_temp"] = "unknown"
+        temp_select.coordinator.data.climate_temp = "unknown"
         assert temp_select.current_option == "normal"
 
     def test_current_option_missing_defaults_normal(self, temp_select):
-        temp_select.coordinator.data.pop("climate_temp", None)
+        temp_select.coordinator.data.climate_temp = None
         assert temp_select.current_option == "normal"
 
     @pytest.mark.asyncio
@@ -77,19 +77,19 @@ class TestClimateDurationSelect:
         assert duration_select._attr_options == ["10", "20", "30"]
 
     def test_current_option_30(self, duration_select):
-        duration_select.coordinator.data["climate_duration"] = 30
+        duration_select.coordinator.data.climate_duration = 30
         assert duration_select.current_option == "30"
 
     def test_current_option_10(self, duration_select):
-        duration_select.coordinator.data["climate_duration"] = 10
+        duration_select.coordinator.data.climate_duration = 10
         assert duration_select.current_option == "10"
 
     def test_current_option_invalid_defaults_30(self, duration_select):
-        duration_select.coordinator.data["climate_duration"] = 99
+        duration_select.coordinator.data.climate_duration = 99
         assert duration_select.current_option == "30"
 
     def test_current_option_missing_defaults_30(self, duration_select):
-        duration_select.coordinator.data.pop("climate_duration", None)
+        duration_select.coordinator.data.climate_duration = None
         assert duration_select.current_option == "30"
 
     @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -55,12 +55,12 @@ class TestHondaSensor:
         assert sensor.native_value is None
 
     def test_list_value_joins(self, mock_coordinator):
-        mock_coordinator.data["warning_lamps"] = ["oil", "tire"]
+        mock_coordinator.data.warning_lamps = ["oil", "tire"]
         sensor = make_sensor(mock_coordinator, "warning_lamps")
         assert sensor.native_value == "oil, tire"
 
     def test_empty_list_returns_none_string(self, mock_coordinator):
-        mock_coordinator.data["warning_lamps"] = []
+        mock_coordinator.data.warning_lamps = []
         sensor = make_sensor(mock_coordinator, "warning_lamps")
         assert sensor.native_value == "none"
 
@@ -84,17 +84,17 @@ class TestHondaSensor:
         assert sensor.native_unit_of_measurement == "°C"
 
     def test_dynamic_unit_distance_miles(self, mock_coordinator):
-        mock_coordinator.data["distance_unit"] = "miles"
+        mock_coordinator.data.distance_unit = "miles"
         sensor = make_sensor(mock_coordinator, "range_climate_on")
         assert sensor.native_unit_of_measurement == "mi"
 
     def test_dynamic_unit_speed_miles(self, mock_coordinator):
-        mock_coordinator.data["distance_unit"] = "miles"
+        mock_coordinator.data.distance_unit = "miles"
         sensor = make_sensor(mock_coordinator, "speed")
         assert sensor.native_unit_of_measurement == "mph"
 
     def test_dynamic_unit_temp_miles(self, mock_coordinator):
-        mock_coordinator.data["distance_unit"] = "miles"
+        mock_coordinator.data.distance_unit = "miles"
         sensor = make_sensor(mock_coordinator, "cabin_temp")
         assert sensor.native_unit_of_measurement == "°F"
 
@@ -128,7 +128,7 @@ class TestHondaSensor:
         assert sensor.extra_state_attributes is None
 
     def test_schedule_empty_list(self, mock_coordinator):
-        mock_coordinator.data["charge_schedule"] = []
+        mock_coordinator.data.charge_schedule = []
         sensor = make_sensor(mock_coordinator, "charge_schedule")
         assert sensor.native_value == 0
         assert sensor.extra_state_attributes == {"rules": []}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -31,31 +31,31 @@ def charge_switch(mock_coordinator):
 
 class TestClimateSwitch:
     def test_is_on_true(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = True
+        climate_switch.coordinator.data.climate_active = True
         assert climate_switch.is_on is True
 
     def test_is_on_false(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = False
+        climate_switch.coordinator.data.climate_active = False
         assert climate_switch.is_on is False
 
     def test_is_on_string_active(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = "active"
+        climate_switch.coordinator.data.climate_active = "active"
         assert climate_switch.is_on is True
 
     def test_is_on_string_true(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = "true"
+        climate_switch.coordinator.data.climate_active = "true"
         assert climate_switch.is_on is True
 
     def test_is_on_string_false(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = "false"
+        climate_switch.coordinator.data.climate_active = "false"
         assert climate_switch.is_on is False
 
     def test_is_on_none(self, climate_switch):
-        climate_switch.coordinator.data["climate_active"] = None
+        climate_switch.coordinator.data.climate_active = None
         assert climate_switch.is_on is None
 
     def test_is_on_missing_key(self, climate_switch):
-        climate_switch.coordinator.data.pop("climate_active", None)
+        climate_switch.coordinator.data.climate_active = None
         assert climate_switch.is_on is None
 
     @pytest.mark.asyncio
@@ -95,38 +95,38 @@ class TestClimateSwitch:
 
 class TestChargeSwitch:
     def test_is_on_charging(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = "charging"
+        charge_switch.coordinator.data.charge_status = "charging"
         assert charge_switch.is_on is True
 
     def test_is_on_running(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = "running"
+        charge_switch.coordinator.data.charge_status = "running"
         assert charge_switch.is_on is True
 
     def test_is_on_not_charging(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = "not_charging"
+        charge_switch.coordinator.data.charge_status = "not_charging"
         assert charge_switch.is_on is False
 
     def test_is_on_unknown(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = "unknown"
+        charge_switch.coordinator.data.charge_status = "unknown"
         assert charge_switch.is_on is False
 
     def test_is_on_none(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = None
+        charge_switch.coordinator.data.charge_status = None
         assert charge_switch.is_on is None
 
     def test_is_on_missing_key(self, charge_switch):
-        charge_switch.coordinator.data.pop("charge_status", None)
+        charge_switch.coordinator.data.charge_status = None
         assert charge_switch.is_on is None
 
     def test_is_on_case_insensitive(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = "CHARGING"
+        charge_switch.coordinator.data.charge_status = "CHARGING"
         assert charge_switch.is_on is True
 
-        charge_switch.coordinator.data["charge_status"] = "Running"
+        charge_switch.coordinator.data.charge_status = "Running"
         assert charge_switch.is_on is True
 
     def test_is_on_non_string_truthy(self, charge_switch):
-        charge_switch.coordinator.data["charge_status"] = 1
+        charge_switch.coordinator.data.charge_status = 1
         assert charge_switch.is_on is True
 
     @pytest.mark.asyncio
@@ -180,7 +180,7 @@ class TestDefrostSwitch:
         return sw
 
     def test_is_on_false(self, defrost_switch):
-        defrost_switch.coordinator.data["climate_defrost"] = False
+        defrost_switch.coordinator.data.climate_defrost = False
         assert defrost_switch.is_on is False
 
     @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -62,7 +62,8 @@ class TestClimateSwitch:
     async def test_turn_on(self, climate_switch):
         await climate_switch.async_turn_on()
         climate_switch.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            climate_switch.coordinator.api.remote_climate_start, MOCK_VIN,
+            climate_switch.coordinator.api.remote_climate_start,
+            MOCK_VIN,
         )
         climate_switch.coordinator.async_set_updated_data.assert_called_once()
         data = climate_switch.coordinator.async_set_updated_data.call_args[0][0]
@@ -72,7 +73,8 @@ class TestClimateSwitch:
     async def test_turn_off(self, climate_switch):
         await climate_switch.async_turn_off()
         climate_switch.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            climate_switch.coordinator.api.remote_climate_stop, MOCK_VIN,
+            climate_switch.coordinator.api.remote_climate_stop,
+            MOCK_VIN,
         )
         climate_switch.coordinator.async_set_updated_data.assert_called_once()
         data = climate_switch.coordinator.async_set_updated_data.call_args[0][0]
@@ -131,7 +133,8 @@ class TestChargeSwitch:
     async def test_turn_on(self, charge_switch):
         await charge_switch.async_turn_on()
         charge_switch.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            charge_switch.coordinator.api.remote_charge_start, MOCK_VIN,
+            charge_switch.coordinator.api.remote_charge_start,
+            MOCK_VIN,
         )
         charge_switch.coordinator.async_set_updated_data.assert_called_once()
         data = charge_switch.coordinator.async_set_updated_data.call_args[0][0]
@@ -141,7 +144,8 @@ class TestChargeSwitch:
     async def test_turn_off(self, charge_switch):
         await charge_switch.async_turn_off()
         charge_switch.coordinator.async_send_command_and_wait.assert_awaited_once_with(
-            charge_switch.coordinator.api.remote_charge_stop, MOCK_VIN,
+            charge_switch.coordinator.api.remote_charge_stop,
+            MOCK_VIN,
         )
         charge_switch.coordinator.async_set_updated_data.assert_called_once()
         data = charge_switch.coordinator.async_set_updated_data.call_args[0][0]


### PR DESCRIPTION
## What's new

- One config entry per Honda account instead of one per vehicle — all vehicles auto-discovered on setup
- Services now use a device selector (pick vehicle by name) instead of config_entry selector
- Reauth refreshes the vehicle list automatically (adds new vehicles, removes sold ones)
- Removed-vehicle cleanup: devices/entities for vehicles no longer on the account are cleaned up on reload
- Bump pymyhondaplus to 5.4.0 (thread-safe HondaAPI for shared instance across vehicle coordinators)

## Breaking changes

- Service calls change from `config_entry: "<id>"` to `device: "<device_id>"` — existing automations using `myhondaplus.climate_on`, `myhondaplus.set_charge_schedule`, or `myhondaplus.set_climate_schedule` need updating
- Config entry unique_id changes from VIN to email (transparent migration)

## Migration

- v2→v3 migration is automatic: wraps single-vehicle entry data into a vehicles list, changes unique_id to email
- If multiple v2 entries existed for the same account, they are consolidated into one v3 entry during setup

## Test plan

- [ ] Fresh install with single vehicle account
- [ ] Fresh install with multi-vehicle account
- [x] Upgrade from 4.5.0 single vehicle — entities preserved, no history loss
- [ ] Upgrade from 4.5.0 with two entries for same account — entries merge
- [ ] Reauth flow updates tokens and refreshes vehicle list
- [ ] Service calls work with device selector
- [ ] All 270 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)