### PR TITLE
Release 5.2.0: bump pymyhondaplus to 5.8.2

### DIFF
--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.8.0"],
+  "requirements": ["pymyhondaplus==5.8.2"],
   "version": "5.2.0"
 }

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.7.1b1"],
-  "version": "5.2.0b1"
+  "requirements": ["pymyhondaplus==5.8.0"],
+  "version": "5.2.0"
 }


### PR DESCRIPTION
## Summary

Pin to the latest stable pymyhondaplus (5.8.2) and ship 5.2.0 of the integration.

## Library changes since 5.7.1b1 (the previous pin)

- **5.8.0** — \`charge_status\` normalized to canonical enum (\`charging\` / \`stopped\` / \`unknown\`). Fixes the ENUM sensor rejecting raw \`running\` values when the car is actively charging (#21). Also normalizes \`home_away\` (#18), \`climate_temp\`, and converts GPS to floats. Adds 17 new \`VehicleCapabilities\` fields.
- **5.8.1** — \`VehicleCapabilities\` refactored to be backed by Honda's raw response dict; known attribute names continue to work transparently for the integration's gating pattern (\`getattr(vehicle.capabilities, desc.capability, True)\`).
- **5.8.2** — fixes \`wait_for_geofence\` polling, adds geofence state translations. No HA-visible change since geofence isn't an HA entity.

## Integration code changes

None — the integration uses the boolean attribute access pattern the library still supports, and its sensor options list already includes the canonical \`charging\` value.

## Closes

Closes #18 (home_away normalization)
Closes #21 (charge_status sensor rejecting "running")

## Pre-merge checklist

- [x] \`pytest tests/ -x -q\` — 292 pass against pymyhondaplus 5.8.2
- [x] \`ruff check custom_components/ tests/\` — clean
- [x] pymyhondaplus 5.8.2 is on PyPI