### PR TITLE
Release 5.2.1: include capabilities and ui_config in diagnostics

### DIFF
--- a/custom_components/myhondaplus/diagnostics.py
+++ b/custom_components/myhondaplus/diagnostics.py
@@ -33,6 +33,8 @@ async def async_get_config_entry_diagnostics(
         vehicles_diag[vin] = {
             "coordinator_data": vd.coordinator.data,
             "trip_data": vd.trip_coordinator.data,
+            "capabilities": vd.capabilities.to_dict(),
+            "ui_config": vd.ui_config.to_dict(),
         }
     return {
         "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.8.2"],
-  "version": "5.2.0"
+  "version": "5.2.1"
 }


### PR DESCRIPTION
## Summary

- Diagnostics dump now includes `vehicles.<vin>.capabilities` (with the full Honda `raw` capability map) and `vehicles.<vin>.ui_config`.
- Triggered by #25, where entities went unavailable after the 5.2.0 update because the capability filter rejected them — but the diagnostics dump didn't expose `vehicle.capabilities`, so we couldn't see what Honda actually returned for the account.
- Bumps integration to 5.2.1.

## Test plan

- [x] `ruff check custom_components/myhondaplus/` — clean
- [x] `pytest tests/ -x -q` — 449 passing
- [x] Loaded the dev integration in a local HA, downloaded diagnostics, confirmed the new fields render with the full raw map plus per-field booleans
