### PR TITLE
Cover diagnostics capabilities/ui_config; tighten contributing rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ A 95% coverage gate is enforced in CI.
 ## Submitting changes
 
 1. Fork the repo and create a branch from `main`.
-2. Make your changes. Add tests for new functionality.
+2. Every code change must extend test coverage to exercise the new or modified behavior. Tests go in the same commit/PR as the code — assume existing tests cover only what they explicitly assert. If something genuinely can't be tested, explain why in the PR description.
 3. Run `pytest` and `ruff check` locally.
 4. Open a pull request with a clear description of what you changed and why.
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -71,3 +71,23 @@ class TestDiagnostics:
         for key in TO_REDACT:
             if key in config:
                 assert config[key] == "**REDACTED**"
+
+    @pytest.mark.asyncio
+    async def test_capabilities_included(self, mock_entry_for_diag):
+        hass = MagicMock()
+        result = await async_get_config_entry_diagnostics(hass, mock_entry_for_diag)
+        caps = result["vehicles"][MOCK_VIN]["capabilities"]
+        # raw map is the load-bearing field for debugging — must be present
+        assert "raw" in caps
+        # known per-field booleans should round-trip alongside raw
+        assert "remote_charge" in caps
+        assert "remote_climate" in caps
+        assert "geo_fence" in caps
+
+    @pytest.mark.asyncio
+    async def test_ui_config_included(self, mock_entry_for_diag):
+        hass = MagicMock()
+        result = await async_get_config_entry_diagnostics(hass, mock_entry_for_diag)
+        ui = result["vehicles"][MOCK_VIN]["ui_config"]
+        assert "hide_window_status" in ui
+        assert "hide_internal_temperature" in ui


### PR DESCRIPTION
## Summary

- Adds two test cases to `tests/test_diagnostics.py` asserting that the 5.2.1 diagnostics output includes the new `capabilities` (raw + per-field booleans) and `ui_config` blocks. Coverage gap from #26 — the production code shipped without these assertions.
- Tightens step 2 of `CONTRIBUTING.md`'s *Submitting changes* section: soft "Add tests for new functionality" is replaced with a mandate that every code change extends coverage in the same commit/PR. The 5.2.1 walk-past is what motivated the rephrasing.

## Test plan

- [x] `ruff check tests/` — clean
- [x] `pytest tests/ -x -q` — 451 passing (was 449 before)
