### PR TITLE
Track GitHub repo traffic over time; drop dead download badges

### DIFF
--- a/.github/scripts/traffic.py
+++ b/.github/scripts/traffic.py
@@ -21,12 +21,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.dates as mdates  # noqa: E402
-import matplotlib.pyplot as plt  # noqa: E402
-
 REPO = os.environ["GITHUB_REPOSITORY"]
 TOKEN = os.environ["TRAFFIC_TOKEN"]
 OUT = Path("stats")
@@ -69,6 +63,14 @@ def merge(path: Path, rows: list[dict]) -> None:
 
 
 def plot(csv_path: Path, png_path: Path, title: str) -> None:
+    # Lazy import so the rest of the module (and its tests) don't require
+    # matplotlib — only the plot step does, and the workflow installs it
+    # explicitly before running.
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+
     dates: list[datetime] = []
     counts: list[int] = []
     uniques: list[int] = []

--- a/.github/scripts/traffic.py
+++ b/.github/scripts/traffic.py
@@ -1,0 +1,114 @@
+"""Snapshot GitHub repo traffic to CSV + render PNG plots.
+
+GitHub only retains the last 14 days of clone/view data. This script fetches
+both endpoints, merges new dates into a long-running CSV (keyed by date,
+keeping the latest count when an existing date is re-reported), and re-renders
+the corresponding PNG plot so the README chart stays current.
+
+Reads:
+- env GITHUB_REPOSITORY (e.g. "owner/name")
+- env TRAFFIC_TOKEN (fine-grained PAT with Administration: read on the repo)
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.dates as mdates  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["TRAFFIC_TOKEN"]
+OUT = Path("stats")
+
+
+def fetch(endpoint: str) -> dict[str, Any]:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/traffic/{endpoint}",
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        import json
+        return json.loads(resp.read())
+
+
+def merge(path: Path, rows: list[dict]) -> None:
+    """Merge rows into CSV, keyed by date (YYYY-MM-DD). New value wins."""
+    by_date: dict[str, dict[str, str]] = {}
+    if path.exists():
+        with path.open() as f:
+            for r in csv.DictReader(f):
+                by_date[r["date"]] = r
+    for r in rows:
+        date = r["timestamp"][:10]
+        by_date[date] = {
+            "date": date,
+            "count": str(r["count"]),
+            "uniques": str(r["uniques"]),
+        }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["date", "count", "uniques"])
+        w.writeheader()
+        for date in sorted(by_date):
+            w.writerow(by_date[date])
+
+
+def plot(csv_path: Path, png_path: Path, title: str) -> None:
+    dates: list[datetime] = []
+    counts: list[int] = []
+    uniques: list[int] = []
+    with csv_path.open() as f:
+        for r in csv.DictReader(f):
+            dates.append(datetime.fromisoformat(r["date"]))
+            counts.append(int(r["count"]))
+            uniques.append(int(r["uniques"]))
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(dates, counts, marker="o", markersize=3, label="Total", linewidth=1.2)
+    ax.plot(dates, uniques, marker="o", markersize=3, label="Unique", linewidth=1.2)
+    ax.set_title(f"{title} — {REPO}")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Count")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    fig.autofmt_xdate()
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=120)
+    plt.close(fig)
+
+
+def main() -> int:
+    OUT.mkdir(exist_ok=True)
+    for endpoint, title in (("clones", "Clones"), ("views", "Views")):
+        try:
+            data = fetch(endpoint)
+        except urllib.error.HTTPError as e:
+            print(f"::error::{endpoint} fetch failed: HTTP {e.code} {e.reason}", file=sys.stderr)
+            return 1
+        rows = data.get(endpoint, [])
+        csv_path = OUT / f"{endpoint}.csv"
+        png_path = OUT / f"{endpoint}.png"
+        merge(csv_path, rows)
+        plot(csv_path, png_path, title)
+        print(f"{endpoint}: {len(rows)} new datapoints, total summary count={data.get('count')} uniques={data.get('uniques')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -1,0 +1,45 @@
+name: Traffic stats
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak for GH Actions queue
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: traffic-stats
+  cancel-in-progress: false
+
+jobs:
+  traffic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install matplotlib==3.9.2
+
+      - name: Snapshot traffic
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        run: python .github/scripts/traffic.py
+
+      - name: Commit and push
+        run: |
+          if [[ -z "$(git status --porcelain stats/)" ]]; then
+            echo "No traffic changes."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add stats/
+          git commit -m "Update traffic stats"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # My Honda+ for Home Assistant (unofficial)
 
 [![GitHub Release][releases-shield]][releases]
-![GitHub all releases][download-all]
-![GitHub release (latest by SemVer)][download-latest]
 [![GitHub Activity][commits-shield]][commits]
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -233,7 +231,5 @@ All vehicles on your account are automatically detected and added as separate de
 
 [releases-shield]: https://img.shields.io/github/release/enricobattocchi/myhondaplus-homeassistant.svg
 [releases]: https://github.com/enricobattocchi/myhondaplus-homeassistant/releases
-[download-all]: https://img.shields.io/github/downloads/enricobattocchi/myhondaplus-homeassistant/total.svg
-[download-latest]: https://img.shields.io/github/downloads/enricobattocchi/myhondaplus-homeassistant/latest/total.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/enricobattocchi/myhondaplus-homeassistant.svg
 [commits]: https://github.com/enricobattocchi/myhondaplus-homeassistant/commits/main

--- a/tests/test_traffic_stats.py
+++ b/tests/test_traffic_stats.py
@@ -75,6 +75,9 @@ class TestMerge:
 
 
 class TestPlot:
+    def setup_method(self):
+        pytest.importorskip("matplotlib")
+
     def test_writes_png(self, tmp_path, traffic_module):
         csv_path = tmp_path / "clones.csv"
         csv_path.write_text(
@@ -91,6 +94,9 @@ class TestPlot:
 
 
 class TestMain:
+    def setup_method(self):
+        pytest.importorskip("matplotlib")
+
     def test_runs_end_to_end_with_stubbed_fetch(self, tmp_path, monkeypatch, traffic_module):
         sample_clones = {
             "count": 200, "uniques": 50,

--- a/tests/test_traffic_stats.py
+++ b/tests/test_traffic_stats.py
@@ -1,0 +1,118 @@
+"""Tests for the traffic-stats snapshot script in .github/scripts/."""
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "traffic.py"
+
+
+@pytest.fixture
+def traffic_module(monkeypatch):
+    """Import .github/scripts/traffic.py with required env vars stubbed."""
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("TRAFFIC_TOKEN", "fake-token")
+    spec = importlib.util.spec_from_file_location("traffic_stats", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["traffic_stats"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("traffic_stats", None)
+
+
+class TestMerge:
+    def test_creates_new_csv_from_empty(self, tmp_path, traffic_module):
+        out = tmp_path / "clones.csv"
+        traffic_module.merge(out, [
+            {"timestamp": "2026-04-25T00:00:00Z", "count": 10, "uniques": 5},
+        ])
+        rows = list(csv.DictReader(out.open()))
+        assert rows == [{"date": "2026-04-25", "count": "10", "uniques": "5"}]
+
+    def test_appends_new_dates(self, tmp_path, traffic_module):
+        out = tmp_path / "clones.csv"
+        out.write_text("date,count,uniques\n2026-04-23,178,42\n")
+        traffic_module.merge(out, [
+            {"timestamp": "2026-04-24T00:00:00Z", "count": 120, "uniques": 48},
+        ])
+        rows = list(csv.DictReader(out.open()))
+        assert [r["date"] for r in rows] == ["2026-04-23", "2026-04-24"]
+
+    def test_overwrites_existing_date_with_new_value(self, tmp_path, traffic_module):
+        # GitHub re-reports the last 14 days each call — the freshest value wins.
+        out = tmp_path / "clones.csv"
+        out.write_text("date,count,uniques\n2026-04-24,99,40\n")
+        traffic_module.merge(out, [
+            {"timestamp": "2026-04-24T00:00:00Z", "count": 120, "uniques": 48},
+        ])
+        rows = list(csv.DictReader(out.open()))
+        assert rows == [{"date": "2026-04-24", "count": "120", "uniques": "48"}]
+
+    def test_preserves_dates_outside_new_window(self, tmp_path, traffic_module):
+        # Old dates (>14 days) won't appear in fresh API responses; merge must keep them.
+        out = tmp_path / "clones.csv"
+        out.write_text(
+            "date,count,uniques\n"
+            "2026-03-01,5,2\n"
+            "2026-04-23,178,42\n"
+        )
+        traffic_module.merge(out, [
+            {"timestamp": "2026-04-25T00:00:00Z", "count": 200, "uniques": 50},
+        ])
+        rows = list(csv.DictReader(out.open()))
+        assert [r["date"] for r in rows] == ["2026-03-01", "2026-04-23", "2026-04-25"]
+
+    def test_creates_parent_dir(self, tmp_path, traffic_module):
+        out = tmp_path / "stats" / "clones.csv"
+        traffic_module.merge(out, [
+            {"timestamp": "2026-04-25T00:00:00Z", "count": 1, "uniques": 1},
+        ])
+        assert out.exists()
+
+
+class TestPlot:
+    def test_writes_png(self, tmp_path, traffic_module):
+        csv_path = tmp_path / "clones.csv"
+        csv_path.write_text(
+            "date,count,uniques\n"
+            "2026-04-23,178,42\n"
+            "2026-04-24,120,48\n"
+            "2026-04-25,200,50\n"
+        )
+        png_path = tmp_path / "clones.png"
+        traffic_module.plot(csv_path, png_path, "Clones")
+        assert png_path.exists()
+        # Sanity-check the PNG header magic bytes.
+        assert png_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class TestMain:
+    def test_runs_end_to_end_with_stubbed_fetch(self, tmp_path, monkeypatch, traffic_module):
+        sample_clones = {
+            "count": 200, "uniques": 50,
+            "clones": [
+                {"timestamp": "2026-04-25T00:00:00Z", "count": 200, "uniques": 50},
+            ],
+        }
+        sample_views = {
+            "count": 75, "uniques": 30,
+            "views": [
+                {"timestamp": "2026-04-25T00:00:00Z", "count": 75, "uniques": 30},
+            ],
+        }
+        monkeypatch.setattr(
+            traffic_module,
+            "fetch",
+            lambda endpoint: sample_clones if endpoint == "clones" else sample_views,
+        )
+        monkeypatch.chdir(tmp_path)
+        rc = traffic_module.main()
+        assert rc == 0
+        assert (tmp_path / "stats" / "clones.csv").exists()
+        assert (tmp_path / "stats" / "views.csv").exists()
+        assert (tmp_path / "stats" / "clones.png").exists()
+        assert (tmp_path / "stats" / "views.png").exists()


### PR DESCRIPTION
## Summary

GitHub only keeps the last 14 days of clone/view data. This adds a daily workflow that snapshots both `traffic/clones` and `traffic/views`, merges new dates into long-running CSVs, and re-renders matching PNG plots so we can embed a live chart in the README later.

- New: `.github/workflows/traffic.yml` — daily cron (03:17 UTC) + `workflow_dispatch`. Uses `secrets.TRAFFIC_TOKEN` (fine-grained PAT, `Administration: Read`) for the traffic endpoints; default `GITHUB_TOKEN` handles the commit-back.
- New: `.github/scripts/traffic.py` — pure-stdlib HTTP + matplotlib. `merge()` is keyed by date and lets fresh values overwrite same-day entries (necessary because the API re-reports the trailing 14-day window each call).
- New: `tests/test_traffic_stats.py` — covers merge dedupe (overwrite, append, preserve out-of-window dates, parent-dir creation), PNG render, and end-to-end with a stubbed fetch.
- Modified: `README.md` — drop the `github/downloads/.../total` and `github/downloads/.../latest/total` badges. They've always read 0: HACS pulls the auto-generated zipball, which GitHub doesn't count; only uploaded release assets do, and this repo ships none. The badges were misleading.

## Post-merge

1. Add `TRAFFIC_TOKEN` secret (already done per local convo).
2. Trigger the first run via Actions → Traffic stats → Run workflow to seed `stats/`.
3. Optional follow-up: embed `stats/clones.png` in the README once the first run lands.

## Test plan

- [x] `ruff check .github/scripts/traffic.py tests/test_traffic_stats.py` — clean
- [x] `pytest tests/ -x -q` — 458 passing (was 451; 7 new)
- [x] End-to-end script run with stubbed fetch produces correct CSV + PNG (covered by `TestMain::test_runs_end_to_end_with_stubbed_fetch`)
