### PR TITLE
Push traffic snapshots to orphan stats branch, not main

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -17,7 +17,21 @@ jobs:
   traffic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # The data lives on the orphan `stats` branch so daily auto-commits
+      # don't have to clear `main`'s required-status-check gate.
+      - name: Checkout stats branch (data working tree)
+        uses: actions/checkout@v4
+        with:
+          ref: stats
+          path: data
+
+      # The script lives on `main`; check it out into a separate path
+      # and invoke it from the data working tree.
+      - name: Checkout main (script source)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: code
 
       - uses: actions/setup-python@v5
         with:
@@ -27,12 +41,14 @@ jobs:
         run: pip install matplotlib==3.9.2
 
       - name: Snapshot traffic
+        working-directory: data
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
-        run: python .github/scripts/traffic.py
+        run: python ../code/.github/scripts/traffic.py
 
       - name: Commit and push
+        working-directory: data
         run: |
           if [[ -z "$(git status --porcelain stats/)" ]]; then
             echo "No traffic changes."


### PR DESCRIPTION
## Summary

The first scheduled run of the new `Traffic stats` workflow failed:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 4 of 4 required status checks are expected.
```

`main` requires the four CI checks for any push, but the workflow's daily auto-commit doesn't trigger them — it just tries to push directly. So the data never lands.

Fix: route auto-commits to a dedicated orphan branch (`stats`, created separately with a placeholder README at https://github.com/enricobattocchi/myhondaplus-homeassistant/tree/stats). The workflow now:

- Checks out `stats` into `./data` — the working tree the script writes into, and the push target.
- Checks out `main` into `./code` — where the snapshot script lives, so the script-source-on-main contract holds.
- Runs `python ../code/.github/scripts/traffic.py` from `./data`.
- Commits and pushes from `./data` to `stats`. No protection there.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] `pytest tests/ -x -q` — 458 still passing (no script changes; only workflow plumbing)
- [ ] After merge: re-dispatch `Traffic stats` and confirm a commit lands on `stats`
