### PR TITLE
[codex] Improve agent docs and docs-only CI

### DIFF
--- a/.github/workflows/agents-docs.yml
+++ b/.github/workflows/agents-docs.yml
@@ -1,0 +1,29 @@
+name: Agent Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - AGENTS.md
+      - scripts/check_agents_mirror.py
+      - .github/workflows/agents-docs.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - AGENTS.md
+      - scripts/check_agents_mirror.py
+      - .github/workflows/agents-docs.yml
+
+jobs:
+  mirror:
+    name: AGENTS mirror
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check mirrored sections
+        run: python scripts/check_agents_mirror.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,49 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        name: Classify changed files
+        shell: bash
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse HEAD^ 2>/dev/null || true)"
+          fi
+
+          if [ -n "$base_sha" ]; then
+            changed_files="$(git diff --name-only "$base_sha" "$GITHUB_SHA")"
+          else
+            changed_files="$(git ls-files)"
+          fi
+
+          code_changed=false
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            case "$path" in
+              *.md|docs/*|docs/**|scripts/check_agents_mirror.py|.github/workflows/agents-docs.yml)
+                ;;
+              *)
+                code_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
+
   ruff:
     name: Ruff
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,49 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        name: Classify changed files
+        shell: bash
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse HEAD^ 2>/dev/null || true)"
+          fi
+
+          if [ -n "$base_sha" ]; then
+            changed_files="$(git diff --name-only "$base_sha" "$GITHUB_SHA")"
+          else
+            changed_files="$(git ls-files)"
+          fi
+
+          code_changed=false
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            case "$path" in
+              *.md|docs/*|docs/**|scripts/check_agents_mirror.py|.github/workflows/agents-docs.yml)
+                ;;
+              *)
+                code_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
+
   test:
     name: Pytest
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Refer to the upstream service as "the My Honda+ API" or "the Honda Connect Europ
 
 [`pymyhondaplus`](https://github.com/enricobattocchi/pymyhondaplus) (Python library + CLI) is consumed by:
 
-- `myhondaplus-homeassistant` (this repo) — Home Assistant integration, pinned `==X.Y.Z` (HA convention).
+- [`myhondaplus-homeassistant`](https://github.com/enricobattocchi/myhondaplus-homeassistant) — Home Assistant integration, pinned `==X.Y.Z` (HA convention).
 - [`myhondaplus-desktop`](https://github.com/enricobattocchi/myhondaplus-desktop) — PyQt6 desktop app, pinned `>=X.Y.Z`.
 
 **Ownership boundaries** — each concern lives in exactly one repo:
@@ -52,6 +52,7 @@ If a task feels like it crosses boundaries, default to "the library owns the API
 - **Release order is library first, then consumers.** Bump `pymyhondaplus`, tag, GitHub-release; then update HA `manifest.json` `requirements` (`==X.Y.Z`) and/or desktop `pyproject.toml` + `README.md` (`>=X.Y.Z`), then release each consumer.
 - **Pin update rule**: HA pins exact (Home Assistant convention); desktop pins minimum.
 - **Translation-drift PRs** may span library + HA. When a string converges in wording, move the pair from `_KNOWN_DRIFT` to `ENFORCED_OVERLAPS` in the same PR (HA test: `tests/test_translation_drift.py`).
+- **Cross-repo change checklist**: land library-owned API/parsing/auth/translation behavior in `pymyhondaplus` first; update HA's exact pin and desktop's minimum pin only after a library release; keep consumer enum options, entity descriptors, and UI copy aligned with canonical library behavior.
 
 ## 6. Common pitfalls
 
@@ -62,7 +63,12 @@ If a task feels like it crosses boundaries, default to "the library owns the API
 - Optimistic updates mutate `coordinator.data` before the API confirms; revert on failure.
 - All 13 locale files must stay current — auditing them is a blocking pre-tag step.
 
-## 7. Gates
+## 7. Gates and local commands
+
+- Setup: `pip install -e ".[dev]"`
+- Tests: `python -m pytest tests/ -x -q`
+- Lint: `ruff check custom_components/ tests/`
+- CI coverage gate: `pytest tests/ -v --cov=custom_components/myhondaplus --cov-report=term-missing --cov-fail-under=95`
 
 `Lint` (ruff), `Test` (pytest with 95% coverage), `Hassfest`, `HACS Validation` — all four required before merge. Tag is the bare version (e.g. `5.2.0`, not `v5.2.0`); `manifest.json` integration `version` must match the tag.
 

--- a/scripts/check_agents_mirror.py
+++ b/scripts/check_agents_mirror.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check consumer AGENTS.md mirrored sections against pymyhondaplus."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+CANONICAL_URL = (
+    "https://raw.githubusercontent.com/enricobattocchi/pymyhondaplus/main/AGENTS.md"
+)
+MIRRORED_HEADINGS = (
+    "## 2. Naming",
+    "## 3. The three-repo ecosystem",
+    "## 5. Cross-repo workflows",
+)
+MIRROR_MARKER_RE = re.compile(r"^\*Mirrored from `pymyhondaplus/AGENTS\.md` .*")
+
+
+def _read_canonical(repo_root: Path) -> str:
+    override = os.environ.get("AGENTS_CANONICAL_PATH")
+    candidates = []
+    if override:
+        candidates.append(Path(override))
+    candidates.append(repo_root.parent / "pymyhondaplus" / "AGENTS.md")
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+
+    with urllib.request.urlopen(CANONICAL_URL, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def _extract_section(text: str, heading: str) -> str:
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError:
+        raise SystemExit(f"Missing heading: {heading}") from None
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _normalize(section: str) -> str:
+    lines = []
+    for line in section.splitlines():
+        if MIRROR_MARKER_RE.match(line):
+            continue
+        lines.append(line.rstrip())
+    compacted = []
+    for line in lines:
+        if line == "" and compacted and compacted[-1] == "":
+            continue
+        compacted.append(line)
+    return "\n".join(compacted).strip() + "\n"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    local_text = (repo_root / "AGENTS.md").read_text(encoding="utf-8")
+    canonical_text = _read_canonical(repo_root)
+
+    failed = False
+    for heading in MIRRORED_HEADINGS:
+        local_section = _normalize(_extract_section(local_text, heading))
+        canonical_section = _normalize(_extract_section(canonical_text, heading))
+        if local_section == canonical_section:
+            continue
+
+        failed = True
+        print(f"Mirrored AGENTS.md section drifted: {heading}", file=sys.stderr)
+        diff = difflib.unified_diff(
+            canonical_section.splitlines(),
+            local_section.splitlines(),
+            fromfile="pymyhondaplus/AGENTS.md",
+            tofile="AGENTS.md",
+            lineterm="",
+        )
+        print("\n".join(diff), file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add local command guidance and consistent cross-repo links to AGENTS.md.
- Add an agent-docs mirror check for sections copied from pymyhondaplus.
- Skip lint/test work for docs-only changes while still running a lightweight change detector.

## Validation
- python -B scripts/check_agents_mirror.py
- RUFF_CACHE_DIR=/tmp/ruff-cache ruff check scripts/check_agents_mirror.py

## Notes
- Existing unrelated local files .codex, .coverage, and GOLD_PLAN.md were not included.