### PR TITLE
Bump version to 5.3.0

### DIFF
--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
   "requirements": ["pymyhondaplus==5.8.2"],
-  "version": "5.2.1"
+  "version": "5.3.0"
 }


### PR DESCRIPTION
## Summary

Bumps `manifest.json` version from 5.2.1 to 5.3.0 in preparation for release. No code changes beyond the version string.

## What's in 5.3.0

### Bug fixes

- **#25** (#34): Read sensors and `device_tracker` no longer disappear when Honda's API reports `featureStatus: notSupported` for every capability flag (typical of lapsed subscriptions). The dashboard data is still served by Honda's API in this state — the integration was hiding it client-side as a 5.0.0 regression. Capability flags now gate only command entities (switch / button / lock / select / number); read-only entities check `vehicle.fuel_type` for EV-specific data and otherwise render unconditionally from coordinator state.
- **#33** (#34): The trip-history coordinator no longer polls `/trips` when `journey_history` capability is not Active. Mirrors the official Honda app's behavior and avoids exposing potentially-stale data on lapsed accounts.

### Behavior changes

- **#36** (#37): Removed the manual-VIN setup fallback. When Honda's API returns no vehicles for an account, the config flow now shows a clear "No vehicles found on this account." abort instead of a form that would produce a degraded-mode entry (no `fuel_type`, no `model`, fake all-True capabilities). Aligns HA with the rest of the ecosystem (CLI, desktop, Honda app — none offer manual VIN entry).
- Existing legacy entries with `manual: True` continue to load unchanged via preserved defensive code; they get reconciled on next reauth/rediscovery.
- API/network errors during initial discovery now surface as `cannot_connect` aborts instead of silently dropping into the manual-VIN form.

### Internal

- New `EV_FUEL_TYPES = frozenset({"E", "X"})` constant in `sensor.py`; new `ev_only: bool` field on `HondaSensorDescription` replaces the old `capability: str` field.
- `_fetch_vehicle_metadata` now backfills `fuel_type` from API metadata alongside the existing model-name backfill, healing legacy entries created pre-2.1.0.
- 13-locale translation parity for the new `config.abort.no_vehicles` string, mirrored from the library and enforced by `tests/test_translation_drift.py`.

## Library compatibility

No `pymyhondaplus` bump required. Pin remains `pymyhondaplus==5.8.2`.

## Test plan

- [x] Ruff and Pytest pass locally (478 tests, 95.78% coverage).
- [x] Hassfest + HACS Validation green on the underlying PRs (#34, #37).
- [x] Manual end-to-end test: HA dev ran ~1h40m on a normal account; coordinator + trip coordinator polled successfully throughout (verified during #34 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
