### PR TITLE
Auto-heal legacy manual-VIN entries on startup

### DIFF
--- a/custom_components/myhondaplus/__init__.py
+++ b/custom_components/myhondaplus/__init__.py
@@ -399,26 +399,39 @@ async def _fetch_vehicle_metadata(
 
     vehicles_by_vin = {v.vin: v for v in api_vehicles}
 
-    # Backfill model and fuel_type when missing. fuel_type was introduced
-    # in 2.1.0; older entries that never re-ran discovery have it empty,
-    # which would now hide EV sensors under the fuel_type-based gate.
+    # Self-heal stale entry metadata against the API response:
+    # - Backfill model and fuel_type when missing (fuel_type was introduced
+    #   in 2.1.0; older entries that never re-ran discovery have it empty,
+    #   which would hide EV sensors under the fuel_type-based gate).
+    # - Promote legacy manual-VIN entries (from before #36) to regular
+    #   entries when Honda's API now returns the VIN: copy the metadata
+    #   in and drop the `manual: True` flag. This means users who set up
+    #   via manual VIN don't have to delete + re-add — they just restart.
     vehicle_list = entry.data.get(CONF_VEHICLES, [])
-    needs_update = any(
-        not v.get(CONF_MODEL) or not v.get(CONF_FUEL_TYPE) for v in vehicle_list
-    )
-    if needs_update:
-        updated = []
-        for v in vehicle_list:
-            api_v = vehicles_by_vin.get(v[CONF_VIN])
-            if not api_v:
-                updated.append(v)
-                continue
-            patch = {}
-            if not v.get(CONF_MODEL):
-                patch[CONF_MODEL] = _build_model_name_from_vehicle(api_v)
-            if not v.get(CONF_FUEL_TYPE) and getattr(api_v, "fuel_type", ""):
-                patch[CONF_FUEL_TYPE] = api_v.fuel_type
-            updated.append({**v, **patch} if patch else v)
+    patches: dict[str, dict] = {}
+    for v in vehicle_list:
+        api_v = vehicles_by_vin.get(v[CONF_VIN])
+        if not api_v:
+            continue
+        new_v = dict(v)
+        changed = False
+        if not new_v.get(CONF_MODEL):
+            new_v[CONF_MODEL] = _build_model_name_from_vehicle(api_v)
+            changed = True
+        if not new_v.get(CONF_FUEL_TYPE) and getattr(api_v, "fuel_type", ""):
+            new_v[CONF_FUEL_TYPE] = api_v.fuel_type
+            changed = True
+        if not new_v.get(CONF_VEHICLE_NAME) and getattr(api_v, "name", ""):
+            new_v[CONF_VEHICLE_NAME] = api_v.name
+            changed = True
+        if new_v.get("manual"):
+            del new_v["manual"]
+            changed = True
+        if changed:
+            patches[v[CONF_VIN]] = new_v
+
+    if patches:
+        updated = [patches.get(v[CONF_VIN], v) for v in vehicle_list]
         hass.config_entries.async_update_entry(
             entry,
             data={**entry.data, CONF_VEHICLES: updated},

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -1174,13 +1174,9 @@ class TestFetchVehicleMetadata:
         hass.config_entries.async_update_entry.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_no_fuel_type_backfill_when_api_lacks_it(self):
-        """Manual-VIN entries (no API metadata) keep their empty fuel_type."""
-        from custom_components.myhondaplus.const import (
-            CONF_FUEL_TYPE,
-            CONF_VEHICLES,
-            CONF_VIN,
-        )
+    async def test_no_backfill_when_api_lacks_vehicle(self):
+        """Legacy manual-VIN entries Honda still doesn't list stay unchanged."""
+        from custom_components.myhondaplus.const import CONF_VEHICLES, CONF_VIN
 
         # API returns NO vehicle for this VIN — simulates a legacy manual-VIN
         # entry (the manual-VIN setup path was removed in #36).
@@ -1191,15 +1187,64 @@ class TestFetchVehicleMetadata:
         entry.data = {
             **MOCK_ENTRY_DATA,
             CONF_VEHICLES: [
-                {CONF_VIN: MOCK_VIN, CONF_FUEL_TYPE: "", "model": "Honda e"}
+                {CONF_VIN: MOCK_VIN, "fuel_type": "", "model": "", "manual": True}
             ],
         }
 
         await _fetch_vehicle_metadata(hass, entry, api)
-        # update_entry called because fuel_type is missing, but no patch applied
-        if hass.config_entries.async_update_entry.called:
-            new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
-            assert new_data[CONF_VEHICLES][0][CONF_FUEL_TYPE] == ""
+
+        # No api_v means no patch — entry stays as-is, no update_entry call.
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_heals_legacy_manual_entry_when_api_lists_vin(self):
+        """Legacy manual-VIN entry self-heals when Honda's API now returns the VIN.
+
+        Drops the `manual: True` flag, backfills fuel_type / model / name from
+        the API response. User doesn't have to delete + re-add the integration.
+        """
+        from custom_components.myhondaplus.const import (
+            CONF_FUEL_TYPE,
+            CONF_MODEL,
+            CONF_VEHICLE_NAME,
+            CONF_VEHICLES,
+            CONF_VIN,
+        )
+
+        vehicle = Vehicle(
+            vin=MOCK_VIN,
+            name="My Honda e",
+            model_name="Honda e",
+            grade="Advance",
+            model_year="2020",
+            fuel_type="E",
+        )
+        api = MagicMock()
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(return_value=[vehicle])
+        entry = MagicMock()
+        entry.data = {
+            **MOCK_ENTRY_DATA,
+            CONF_VEHICLES: [
+                {
+                    CONF_VIN: MOCK_VIN,
+                    CONF_VEHICLE_NAME: "",
+                    CONF_FUEL_TYPE: "",
+                    CONF_MODEL: "",
+                    "manual": True,
+                }
+            ],
+        }
+
+        await _fetch_vehicle_metadata(hass, entry, api)
+
+        hass.config_entries.async_update_entry.assert_called_once()
+        new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        new_vehicle = new_data[CONF_VEHICLES][0]
+        assert new_vehicle[CONF_FUEL_TYPE] == "E"
+        assert new_vehicle[CONF_VEHICLE_NAME] == "My Honda e"
+        assert new_vehicle[CONF_MODEL].startswith("Honda e")
+        assert "manual" not in new_vehicle
 
 
 class TestSensorEnabled:


### PR DESCRIPTION
## Summary

Legacy entries created via the manual-VIN form (removed in #36) self-heal on integration startup when Honda's API now returns metadata for the VIN: drops the `manual: True` flag, copies in name / model / fuel_type. No user action required beyond restarting HA.

If Honda's API still doesn't list the VIN, the entry stays as-is.

## What changed

- `_fetch_vehicle_metadata`: backfill loop refactored to a single patches dict; `update_entry` is now called only when something actually changed.
- Auto-heal logic: when API returns metadata for an entry's VIN, drop the `manual` flag if present and backfill any missing `name` / `model` / `fuel_type`.
- Tests: `test_auto_heals_legacy_manual_entry_when_api_lists_vin` and `test_no_backfill_when_api_lacks_vehicle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
