### PR TITLE
fix: decouple temperature unit from distance unit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ When updating a translation on either side, run the drift test. If a key crosses
 
 - `to_bool()` in `entity.py` handles API values that arrive as strings (`"true"`/`"false"`), ints, or actual bools.
 - Enum sensors must list all possible values in `options`. The library normalizes values; this integration does not re-normalize.
-- Dynamic units (km/miles, km/h/mph, C/F) come from `data.distance_unit` via `UNIT_MAP` in `sensor.py`.
+- Dynamic units in `sensor.py`: distance and speed (km/miles, km/h/mph) come from `data.distance_unit` via `UNIT_MAP`; temperature (°C/°F) comes from `data.temp_unit` via `TEMP_UNIT_MAP`. The two are independent because some locales mix metric and imperial (UK uses miles + °C).
 - Optimistic updates: entity commands mutate `coordinator.data` before API confirmation, revert on failure.
 - Entity gating policy:
   - Read-only entities (sensor, binary_sensor, device_tracker) are **not** gated on `VehicleCapabilities`. They check `_sensor_enabled()` against `ev_only` (filtered by vehicle `fuel_type`, where `"E"`=BEV and `"X"`=PHEV) and `ui_hide` flags. This is so dashboard data stays visible when Honda's capability map flips to all-`notSupported` (e.g. lapsed subscription) but the data still flows.

--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.9.0"],
-  "version": "5.4.0"
+  "requirements": ["pymyhondaplus==5.10.0"],
+  "version": "5.4.1"
 }

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -23,8 +23,13 @@ from .entity import MyHondaPlusEntity
 PARALLEL_UPDATES = 0
 
 UNIT_MAP = {
-    "km": {"distance": "km", "speed": "km/h", "temp": "°C"},
-    "miles": {"distance": "mi", "speed": "mph", "temp": "°F"},
+    "km": {"distance": "km", "speed": "km/h"},
+    "miles": {"distance": "mi", "speed": "mph"},
+}
+
+TEMP_UNIT_MAP = {
+    "c": "°C",
+    "f": "°F",
 }
 
 EV_FUEL_TYPES = frozenset({"E", "X"})
@@ -293,6 +298,9 @@ def _resolve_unit(data, description: HondaSensorDescription) -> str | None:
     """Resolve the unit of measurement from coordinator data."""
     if not description.dynamic_unit or not data:
         return description.native_unit_of_measurement
+    if description.dynamic_unit == "temp":
+        temp_unit = getattr(data, "temp_unit", "c")
+        return TEMP_UNIT_MAP.get(str(temp_unit).lower(), TEMP_UNIT_MAP["c"])
     distance_unit = data.distance_unit if hasattr(data, "distance_unit") else "km"
     units = UNIT_MAP.get(distance_unit, UNIT_MAP["km"])
     return units.get(description.dynamic_unit)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -93,8 +93,15 @@ class TestHondaSensor:
         sensor = make_sensor(mock_coordinator, "speed")
         assert sensor.native_unit_of_measurement == "mph"
 
-    def test_dynamic_unit_temp_miles(self, mock_coordinator):
+    def test_dynamic_unit_temp_independent_of_distance(self, mock_coordinator):
+        """UK uses miles but Celsius; temp must follow temp_unit, not distance_unit."""
         mock_coordinator.data.distance_unit = "miles"
+        mock_coordinator.data.temp_unit = "c"
+        sensor = make_sensor(mock_coordinator, "cabin_temp")
+        assert sensor.native_unit_of_measurement == "°C"
+
+    def test_dynamic_unit_temp_fahrenheit(self, mock_coordinator):
+        mock_coordinator.data.temp_unit = "f"
         sensor = make_sensor(mock_coordinator, "cabin_temp")
         assert sensor.native_unit_of_measurement == "°F"
 


### PR DESCRIPTION
UK accounts get miles for distance/speed but Celsius for temperature. The previous `UNIT_MAP` keyed temperature off `distance_unit`, so once pymyhondaplus canonicalizes the Honda UK alias `mile` → `miles` (enricobattocchi/pymyhondaplus#19), `cabin_temp` / `interior_temp` would flip to `°F` on UK cars, which is wrong.

## Changes

- Split `TEMP_UNIT_MAP` keyed on `data.temp_unit` (`c` → `°C`, `f` → `°F`).
- `_resolve_unit` reads `temp_unit` directly for `dynamic_unit="temp"`. Distance and speed still come from `distance_unit`.

The user-visible fix lands when the next pymyhondaplus release ships and the HA manifest pin is bumped in the release PR.

## Tests

- `test_dynamic_unit_temp_independent_of_distance`: miles + `temp_unit='c'` keeps `°C`.
- `test_dynamic_unit_temp_fahrenheit`: explicit `temp_unit='f'` path.

Refs #47
