### PR TITLE
fix: read distance_unit/temp_unit from trip dict too

### DIFF
--- a/custom_components/myhondaplus/manifest.json
+++ b/custom_components/myhondaplus/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/enricobattocchi/myhondaplus-homeassistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/enricobattocchi/myhondaplus-homeassistant/issues",
-  "requirements": ["pymyhondaplus==5.10.0"],
-  "version": "5.4.1"
+  "requirements": ["pymyhondaplus==5.10.1"],
+  "version": "5.4.2"
 }

--- a/custom_components/myhondaplus/sensor.py
+++ b/custom_components/myhondaplus/sensor.py
@@ -294,14 +294,23 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+def _read_unit(data, key: str, default: str) -> str:
+    """Read a unit field from either a DashboardData dataclass or a trip dict."""
+    if hasattr(data, key):
+        return getattr(data, key)
+    if isinstance(data, dict):
+        return data.get(key, default)
+    return default
+
+
 def _resolve_unit(data, description: HondaSensorDescription) -> str | None:
     """Resolve the unit of measurement from coordinator data."""
     if not description.dynamic_unit or not data:
         return description.native_unit_of_measurement
     if description.dynamic_unit == "temp":
-        temp_unit = getattr(data, "temp_unit", "c")
+        temp_unit = _read_unit(data, "temp_unit", "c")
         return TEMP_UNIT_MAP.get(str(temp_unit).lower(), TEMP_UNIT_MAP["c"])
-    distance_unit = data.distance_unit if hasattr(data, "distance_unit") else "km"
+    distance_unit = _read_unit(data, "distance_unit", "km")
     units = UNIT_MAP.get(distance_unit, UNIT_MAP["km"])
     return units.get(description.dynamic_unit)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -171,3 +171,11 @@ class TestHondaTripSensor:
     def test_distance_unit_dynamic(self, mock_trip_coordinator):
         sensor = make_trip_sensor(mock_trip_coordinator, "total_distance")
         assert sensor.native_unit_of_measurement == "km"
+
+    def test_distance_unit_dynamic_miles(self, mock_trip_coordinator):
+        """Trip data is a dict, so distance_unit must be read via .get(), not getattr()."""
+        mock_trip_coordinator.data = dict(mock_trip_coordinator.data,
+                                          distance_unit="miles",
+                                          speed_unit="miles/h")
+        sensor = make_trip_sensor(mock_trip_coordinator, "total_distance")
+        assert sensor.native_unit_of_measurement == "mi"


### PR DESCRIPTION
In `_resolve_unit`, `distance_unit` and `temp_unit` were read via attribute access. That works for the dashboard coordinator's `DashboardData` dataclass, but the trip coordinator's data is a plain dict, so `hasattr(data, "distance_unit")` is `False` and the lookup falls back to `"km"` regardless of what pymyhondaplus actually emitted.

Effect on UK users after 5.4.1:

- 8 of 9 distance/range/speed/temperature entities label correctly (`mi`/`mph`/`°C`).
- `sensor.<vehicle>_distance_this_month` keeps `km` on a value that is actually miles.

Caught during local-instance verification of the 5.4.1 release.

## Changes

- Small helper `_read_unit(data, key, default)` reads from a dataclass attribute or a dict key.
- `_resolve_unit` uses it for both `distance_unit` and `temp_unit`.

## Tests

- `test_distance_unit_dynamic_miles`: trip coordinator with `distance_unit="miles"` in its dict → `total_distance` sensor reports `mi`.

Refs #47
